### PR TITLE
Use a custom block for storing a Z3_config in the ML bindings.

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1376,8 +1376,10 @@ def mk_z3native_stubs_c(ml_dir): # C interface
             ts = type2str(result)
             if ml_has_plus_type(ts):
                 ml_wrapper.write('%s z3rv_m = ' % ts)
+            elif (result == BOOL or result == INT or result == UINT or result == PRINT_MODE or result == ERROR_CODE or result ==INT64 or result == UINT64 or result == DOUBLE or result == STRING):
+                ml_wrapper.write('%s z3rv = ' % ts)
             else:
-                ml_wrapper.write('result = caml_alloc(%s, 0);\n  ' % ret_size)
+                ml_wrapper.write('result = caml_alloc_custom(&default_custom_ops, sizeof(%s), 0, 1);\n  ' % ts)
                 ml_wrapper.write('%s z3rv = ' % ts)
 
         elif len(op) != 0:


### PR DESCRIPTION
This PR removes unnecessary allocations with caml_alloc for return values that do not need an a-priori allocation.

Moreover, it allocates the OCaml value that holds the return value (for non-array, non-plus values) as custom blocks instead of a structued OCaml block using caml_alloc. This is necessary, as, e.g. the values that encapsulate a Z3_config are otherwise wrongly treated by OCaml's GC, resulting in a segmentation fault.
