### PR TITLE
Improvements of the OCaml API implementation

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1208,9 +1208,9 @@ def mk_ml(ml_dir):
         ml_native.write(s);
     ml_pref.close()
 
-    ml_native.write('module ML2C = struct\n\n')
+    ml_native.write('\n')
     for name, result, params in _dotnet_decls:
-        ml_native.write('    external n_%s : ' % ml_method_name(name))
+        ml_native.write('external %s : ' % ml_method_name(name))
         ip = inparams(params)
         op = outparams(params)
         if len(ip) == 0:
@@ -1231,55 +1231,20 @@ def mk_ml(ml_dir):
             ml_native.write('%s' % param2ml(p))
         if len(op) > 0:
             ml_native.write(')')
-        ml_native.write('\n')
         if len(ip) > 5:
-            ml_native.write('      = "n_%s_bytecode"\n' % ml_method_name(name))
-            ml_native.write('        "n_%s"\n' % ml_method_name(name))
+            ml_native.write('  = "n_%s_bytecode" "n_%s"\n' % (ml_method_name(name), ml_method_name(name)))
         else:
-            ml_native.write('      = "n_%s"\n' % ml_method_name(name))
+            ml_native.write('  = "n_%s"\n' % ml_method_name(name))
         ml_native.write('\n')
-    ml_native.write('  end\n\n')
-
-    # Exception wrappers
-    for name, result, params in _dotnet_decls:
-        ip = inparams(params)
-        op = outparams(params)
-        ml_native.write('  let %s ' % ml_method_name(name))
-
-        first = True
-        i = 0
-        for p in params:
-            if is_in_param(p):
-                if first:
-                    first = False
-                else:
-                    ml_native.write(' ')
-                ml_native.write('a%d' % i)
-            i = i + 1
-        if len(ip) == 0:
-            ml_native.write('()')
-        ml_native.write(' = ')
-        ml_native.write('ML2C.n_%s' % (ml_method_name(name)))
-        if len(ip) == 0:
-            ml_native.write(' ()')
-        first = True
-        i = 0
-        for p in params:
-            if is_in_param(p):
-                ml_native.write(' a%d' % i)
-            i = i + 1
-        ml_native.write('\n')
-
-    ml_native.write('\n')
 
     # null pointer helpers
     for type_id in Type2Str:
         type_name = Type2Str[type_id]
         if ml_has_plus_type(type_name) and not type_name in ['Z3_context', 'Z3_sort', 'Z3_func_decl', 'Z3_app', 'Z3_pattern']:
             ml_name = type2ml(type_id)
-            ml_native.write('  external context_of_%s : %s -> context = "n_context_of_%s"\n' % (ml_name, ml_name, ml_name))
-            ml_native.write('  external is_null_%s : %s -> bool = "n_is_null_%s"\n' % (ml_name, ml_name, ml_name))
-            ml_native.write('  external mk_null_%s : context -> %s = "n_mk_null_%s"\n\n' % (ml_name, ml_name, ml_name))
+            ml_native.write('external context_of_%s : %s -> context = "n_context_of_%s"\n' % (ml_name, ml_name, ml_name))
+            ml_native.write('external is_null_%s : %s -> bool = "n_is_null_%s"\n' % (ml_name, ml_name, ml_name))
+            ml_native.write('external mk_null_%s : context -> %s = "n_mk_null_%s"\n\n' % (ml_name, ml_name, ml_name))
 
     ml_native.write('(**/**)\n')
     ml_native.close()

--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -679,13 +679,13 @@ struct
       | _ ->
         let nopatterns_arr = Array.of_list nopatterns in
         Z3native.mk_quantifier_ex ctx universal
-        (match weight with | None -> 1 | Some x -> x)
-        (match quantifier_id with | None -> Z3native.mk_null_symbol ctx | Some x -> x)
-        (match skolem_id with | None -> Z3native.mk_null_symbol ctx | Some x -> x)
-        (Array.length patterns_arr) patterns_arr
-        (Array.length nopatterns_arr) nopatterns_arr
-        (Array.length sorts_arr) sorts_arr
-        names_arr body
+          (match weight with | None -> 1 | Some x -> x)
+          (match quantifier_id with | None -> Z3native.mk_null_symbol ctx | Some x -> x)
+          (match skolem_id with | None -> Z3native.mk_null_symbol ctx | Some x -> x)
+          (Array.length patterns_arr) patterns_arr
+          (Array.length nopatterns_arr) nopatterns_arr
+          (Array.length sorts_arr) sorts_arr
+          names_arr body
 
   let _internal_mk_quantifier_const ~universal ctx bound_constants body weight patterns nopatterns quantifier_id skolem_id =
     let patterns_arr = Array.of_list patterns in

--- a/src/api/ml/z3.mli
+++ b/src/api/ml/z3.mli
@@ -5,19 +5,19 @@
    @author CM Wintersteiger (cwinter) 2012-12-17
 *)
 
-(** General Z3 exceptions 
+(** General Z3 exceptions
 
     Many functions in this API may throw an exception; if they do, it is this one.*)
 exception Error of string
 
 (** Context objects.
 
-    Most interactions with Z3 are interpreted in some context; many users will only 
-    require one such object, but power users may require more than one. To start using 
-    Z3, do 
+    Most interactions with Z3 are interpreted in some context; many users will only
+    require one such object, but power users may require more than one. To start using
+    Z3, do
 
     <code>
-    let ctx = (mk_context []) in 
+    let ctx = (mk_context []) in
     (...)
     </code>
 
@@ -26,17 +26,17 @@ exception Error of string
 
     <code>
     let cfg = [("model", "true"); ("...", "...")] in
-    let ctx = (mk_context cfg) in 
+    let ctx = (mk_context cfg) in
     (...)
     </code>
 *)
 type context
 
-(** Create a context object 
+(** Create a context object
     The following parameters can be set:
-    
+
     - proof  (Boolean)           Enable proof generation
-    - debug_ref_count (Boolean)  Enable debug support for Z3_ast reference counting 
+    - debug_ref_count (Boolean)  Enable debug support for Z3_ast reference counting
     - trace  (Boolean)           Tracing support for VCC
     - trace_file_name (String)   Trace out file for VCC traces
     - timeout (unsigned)         default timeout (in milliseconds) used for solvers
@@ -44,16 +44,16 @@ type context
     - auto_config                use heuristics to automatically select solver and configure it
     - model                      model generation for solvers, this parameter can be overwritten when creating a solver
     - model_validate             validate models produced by solvers
-    - unsat_core                 unsat-core generation for solvers, this parameter can be overwritten when creating a solver    
+    - unsat_core                 unsat-core generation for solvers, this parameter can be overwritten when creating a solver
 *)
 val mk_context : (string * string) list -> context
 
 (** Interaction logging for Z3
-    Note that this is a global, static log and if multiple Context 
+    Note that this is a global, static log and if multiple Context
     objects are created, it logs the interaction with all of them. *)
 module Log :
 sig
-  (** Open an interaction log file. 
+  (** Open an interaction log file.
       @return True if opening the log file succeeds, false otherwise. *)
   (* CMW: "open" is a reserved keyword. *)
   val open_ : string -> bool
@@ -107,7 +107,7 @@ sig
   (** A string representation of the symbol. *)
   val to_string : symbol -> string
 
-  (** Creates a new symbol using an integer.     
+  (** Creates a new symbol using an integer.
       Not all integers can be passed to this function.
       The legal range of unsigned integers is 0 to 2^30-1. *)
   val mk_int : context -> int -> symbol
@@ -125,21 +125,21 @@ end
 (** The abstract syntax tree (AST) module *)
 module rec AST :
 sig
-  type ast 
+  type ast
 
   (** Vectors of ASTs *)
   module ASTVector :
   sig
-    type ast_vector 
+    type ast_vector
 
     (** Create an empty AST vector *)
     val mk_ast_vector : context -> ast_vector
-      
+
     (** The size of the vector *)
     val get_size : ast_vector -> int
 
     (** Retrieves the i-th object in the vector.
-		@return An AST *)
+                @return An AST *)
     val get : ast_vector -> int -> ast
 
     (** Sets the i-th object in the vector. *)
@@ -149,11 +149,11 @@ sig
     val resize : ast_vector -> int -> unit
 
     (** Add an ast to the back of the vector. The size
-		is increased by 1. *)
+                is increased by 1. *)
     val push : ast_vector -> ast -> unit
 
     (** Translates all ASTs in the vector to another context.
-		@return A new ASTVector *)
+                @return A new ASTVector *)
     val translate : ast_vector -> context -> ast_vector
 
     (** Translates the ASTVector into an (Ast.ast list) *)
@@ -173,13 +173,13 @@ sig
 
     (** Create an empty mapping from AST to AST *)
     val mk_ast_map : context -> ast_map
-      
+
     (** Checks whether the map contains a key.
-		@return True if the key in the map, false otherwise. *)
+                @return True if the key in the map, false otherwise. *)
     val contains : ast_map -> ast -> bool
 
     (** Finds the value associated with the key.
-		This function signs an error when the key is not a key in the map. *)
+                This function signs an error when the key is not a key in the map. *)
     val find : ast_map -> ast -> ast
 
     (**   Stores or replaces a new key/value pair in the map. *)
@@ -208,7 +208,7 @@ sig
   (** A unique identifier for the AST (unique among all ASTs). *)
   val get_id : ast -> int
 
-  (** The kind of the AST.  *)    
+  (** The kind of the AST.  *)
   val get_ast_kind : ast -> Z3enums.ast_kind
 
   (** Indicates whether the AST is an Expr *)
@@ -233,7 +233,7 @@ sig
   val to_sexpr : ast -> string
 
   (** Comparison operator.
-      @return True if the two ast's are from the same context 
+      @return True if the two ast's are from the same context
       and represent the same sort; false otherwise. *)
   val equal : ast -> ast -> bool
 
@@ -252,7 +252,7 @@ sig
   type sort
 
   (** Comparison operator.
-      @return True if the two sorts are from the same context 
+      @return True if the two sorts are from the same context
       and represent the same sort; false otherwise. *)
   val equal : sort -> sort -> bool
 
@@ -285,14 +285,14 @@ sig
   sig
     (** Parameters of func_decls *)
     type parameter =
-		P_Int of int
+                P_Int of int
       | P_Dbl of float
       | P_Sym of Symbol.symbol
       | P_Srt of Sort.sort
       | P_Ast of AST.ast
       | P_Fdl of func_decl
       | P_Rat of string
-		  
+
     (** The kind of the parameter. *)
     val get_kind : parameter -> Z3enums.parameter_kind
 
@@ -354,10 +354,10 @@ sig
   (** The size of the domain of the function declaration
       {!get_arity} *)
   val get_domain_size : func_decl -> int
-    
+
   (** The domain of the function declaration *)
   val get_domain : func_decl -> Sort.sort list
-    
+
   (** The range of the function declaration *)
   val get_range : func_decl -> Sort.sort
 
@@ -373,7 +373,7 @@ sig
   (** The parameters of the function declaration *)
   val get_parameters : func_decl -> Parameter.parameter list
 
-  (** Create expression that applies function to arguments. *)	   
+  (** Create expression that applies function to arguments. *)
   val apply : func_decl -> Expr.expr list -> Expr.expr
 end
 
@@ -387,7 +387,7 @@ sig
   (** ParamDescrs describe sets of parameters (of Solvers, Tactics, ...) *)
   module ParamDescrs :
   sig
-    type param_descrs 
+    type param_descrs
 
     (** Validate a set of parameters. *)
     val validate : param_descrs -> params -> unit
@@ -424,19 +424,19 @@ sig
   val to_string : params -> string
 
   (** Update a mutable configuration parameter.
-      
+
       The list of all configuration parameters can be obtained using the Z3 executable:
       [z3.exe -p]
       Only a few configuration parameters are mutable once the context is created.
       An exception is thrown when trying to modify an immutable parameter. *)
   val update_param_value : context -> string -> string -> unit
-    
+
   (** Selects the format used for pretty-printing expressions.
-      
+
       The default mode for pretty printing expressions is to produce
-      SMT-LIB style output where common subexpressions are printed 
+      SMT-LIB style output where common subexpressions are printed
       at each occurrence. The mode is called PRINT_SMTLIB_FULL.
-      To print shared common subexpressions only once, 
+      To print shared common subexpressions only once,
       use the PRINT_LOW_LEVEL mode.
       To print in way that conforms to SMT-LIB standards and uses let
       expressions to share common sub-expressions use PRINT_SMTLIB_COMPLIANT.
@@ -471,7 +471,7 @@ sig
   (** The number of arguments of the expression. *)
   val get_num_args : Expr.expr -> int
 
-  (** The arguments of the expression. *)        
+  (** The arguments of the expression. *)
   val get_args : Expr.expr -> Expr.expr list
 
   (** Update the arguments of the expression using an array of expressions.
@@ -479,9 +479,9 @@ sig
   val update : Expr.expr -> Expr.expr list -> expr
 
   (** Substitute every occurrence of [from[i]] in the expression with [to[i]], for [i] smaller than [num_exprs].
-      
+
       The result is the new expression. The arrays [from] and [to] must have size [num_exprs].
-      For every [i] smaller than [num_exprs], we must have that 
+      For every [i] smaller than [num_exprs], we must have that
       sort of [from[i]] must be equal to sort of [to[i]]. *)
   val substitute : Expr.expr -> Expr.expr list -> Expr.expr list -> expr
 
@@ -498,14 +498,14 @@ sig
       @return A copy of the term which is associated with the other context *)
   val translate : Expr.expr -> context -> expr
 
-  (** Returns a string representation of the expression. *)    
+  (** Returns a string representation of the expression. *)
   val to_string : Expr.expr -> string
 
   (** Indicates whether the term is a numeral *)
   val is_numeral : Expr.expr -> bool
 
   (** Indicates whether the term is well-sorted.
-      @return True if the term is well-sorted, false otherwise. *)   
+      @return True if the term is well-sorted, false otherwise. *)
   val is_well_sorted : Expr.expr -> bool
 
   (** The Sort of the term. *)
@@ -513,31 +513,31 @@ sig
 
   (** Indicates whether the term represents a constant. *)
   val is_const : Expr.expr -> bool
-    
+
   (** Creates a new constant. *)
   val mk_const : context -> Symbol.symbol -> Sort.sort -> expr
-    
+
   (** Creates a new constant. *)
   val mk_const_s : context -> string -> Sort.sort -> expr
-    
+
   (** Creates a  constant from the func_decl. *)
   val mk_const_f : context -> FuncDecl.func_decl -> expr
-    
+
   (** Creates a fresh constant with a name prefixed with a string. *)
   val mk_fresh_const : context -> string -> Sort.sort -> expr
-    
+
   (** Create a new function application. *)
   val mk_app : context -> FuncDecl.func_decl -> Expr.expr list -> expr
-    
-  (** Create a numeral of a given sort.         
+
+  (** Create a numeral of a given sort.
       @return A Term with the given value and sort *)
   val mk_numeral_string : context -> string -> Sort.sort -> expr
-    
+
   (** Create a numeral of a given sort. This function can be use to create numerals that fit in a machine integer.
-      It is slightly faster than [MakeNumeral] since it is not necessary to parse a string.       
+      It is slightly faster than [MakeNumeral] since it is not necessary to parse a string.
       @return A Term with the given value and sort *)
   val mk_numeral_int : context -> int -> Sort.sort -> expr
-    
+
   (** Comparison operator.
       @return True if the two expr's are equal; false otherwise. *)
   val equal : expr -> expr -> bool
@@ -553,22 +553,22 @@ sig
   (** Create a Boolean sort *)
   val mk_sort : context -> Sort.sort
 
-  (** Create a Boolean constant. *)        
+  (** Create a Boolean constant. *)
   val mk_const : context -> Symbol.symbol -> Expr.expr
 
-  (** Create a Boolean constant. *)        
+  (** Create a Boolean constant. *)
   val mk_const_s : context -> string -> Expr.expr
 
-  (** The true Term. *)    
+  (** The true Term. *)
   val mk_true : context -> Expr.expr
 
-  (** The false Term. *)    
+  (** The false Term. *)
   val mk_false : context -> Expr.expr
 
-  (** Creates a Boolean value. *)        
+  (** Creates a Boolean value. *)
   val mk_val : context -> bool -> Expr.expr
 
-  (** Mk an expression representing [not(a)]. *)    
+  (** Mk an expression representing [not(a)]. *)
   val mk_not : context -> Expr.expr -> Expr.expr
 
   (** Create an expression representing an if-then-else: [ite(t1, t2, t3)]. *)
@@ -665,7 +665,7 @@ sig
 
 
   (** The de-Burijn index of a bound variable.
-      
+
       Bound variables are indexed by de-Bruijn indices. It is perhaps easiest to explain
       the meaning of de-Bruijn indices by indicating the compilation process from
       non-de-Bruijn formulas to de-Bruijn format.
@@ -696,19 +696,19 @@ sig
 
   (** The patterns. *)
   val get_patterns : quantifier -> Pattern.pattern list
-    
+
   (** The number of no-patterns. *)
   val get_num_no_patterns : quantifier -> int
-    
+
   (** The no-patterns. *)
   val get_no_patterns : quantifier -> Pattern.pattern list
 
   (** The number of bound variables. *)
   val get_num_bound : quantifier -> int
-    
+
   (** The symbols for the bound variables. *)
   val get_bound_variable_names : quantifier -> Symbol.symbol list
-    
+
   (** The sorts of the bound variables. *)
   val get_bound_variable_sorts : quantifier -> Sort.sort list
 
@@ -735,7 +735,7 @@ sig
 
   (** Create a Quantifier. *)
   val mk_quantifier : context -> Sort.sort list -> Symbol.symbol list -> Expr.expr -> int option -> Pattern.pattern list -> Expr.expr list -> Symbol.symbol option -> Symbol.symbol option -> quantifier
-    
+
   (** Create a Quantifier. *)
   val mk_quantifier : context -> bool -> Expr.expr list -> Expr.expr -> int option -> Pattern.pattern list -> Expr.expr list -> Symbol.symbol option -> Symbol.symbol option -> quantifier
 
@@ -749,28 +749,28 @@ sig
   (** Create a new array sort. *)
   val mk_sort : context -> Sort.sort -> Sort.sort -> Sort.sort
 
-  (** Indicates whether the term is an array store.        
-      It satisfies select(store(a,i,v),j) = if i = j then v else select(a,j). 
+  (** Indicates whether the term is an array store.
+      It satisfies select(store(a,i,v),j) = if i = j then v else select(a,j).
       Array store takes at least 3 arguments.  *)
   val is_store : Expr.expr -> bool
 
   (** Indicates whether the term is an array select. *)
   val is_select : Expr.expr -> bool
 
-  (** Indicates whether the term is a constant array.        
+  (** Indicates whether the term is a constant array.
       For example, select(const(v),i) = v holds for every v and i. The function is unary. *)
   val is_constant_array : Expr.expr -> bool
 
-  (** Indicates whether the term is a default array.        
+  (** Indicates whether the term is a default array.
       For example default(const(v)) = v. The function is unary. *)
   val is_default_array : Expr.expr -> bool
 
-  (** Indicates whether the term is an array map.     
+  (** Indicates whether the term is an array map.
       It satisfies map[f](a1,..,a_n)[i] = f(a1[i],...,a_n[i]) for every i. *)
   val is_array_map : Expr.expr -> bool
 
-  (** Indicates whether the term is an as-array term.        
-      An as-array term is n array value that behaves as the function graph of the 
+  (** Indicates whether the term is an as-array term.
+      An as-array term is n array value that behaves as the function graph of the
       function passed as parameter. *)
   val is_as_array : Expr.expr -> bool
 
@@ -779,54 +779,54 @@ sig
 
   (** The domain of the array sort. *)
   val get_domain : Sort.sort -> Sort.sort
-    
+
   (** The range of the array sort. *)
   val get_range : Sort.sort -> Sort.sort
-    
-  (** Create an array constant. *)        
+
+  (** Create an array constant. *)
   val mk_const : context -> Symbol.symbol -> Sort.sort -> Sort.sort -> Expr.expr
-    
-  (** Create an array constant. *)        
+
+  (** Create an array constant. *)
   val mk_const_s : context -> string -> Sort.sort -> Sort.sort -> Expr.expr
-    
-  (** Array read.       
-      
-      The argument [a] is the array and [i] is the index 
-      of the array that gets read.      
-      
-      The node [a] must have an array sort [[domain -> range]], 
+
+  (** Array read.
+
+      The argument [a] is the array and [i] is the index
+      of the array that gets read.
+
+      The node [a] must have an array sort [[domain -> range]],
       and [i] must have the sort [domain].
       The sort of the result is [range].
       {!Z3Array.mk_sort}
       {!mk_store} *)
   val mk_select : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Array update.       
-      
-      The node [a] must have an array sort [[domain -> range]], 
+  (** Array update.
+
+      The node [a] must have an array sort [[domain -> range]],
       [i] must have sort [domain],
       [v] must have sort range. The sort of the result is [[domain -> range]].
       The semantics of this function is given by the theory of arrays described in the SMT-LIB
       standard. See http://smtlib.org for more details.
-      The result of this function is an array that is equal to [a] 
+      The result of this function is an array that is equal to [a]
       (with respect to [select])
-      on all indices except for [i], where it maps to [v] 
-      (and the [select] of [a] with 
+      on all indices except for [i], where it maps to [v]
+      (and the [select] of [a] with
       respect to [i] may be a different value).
       {!Z3Array.mk_sort}
       {!mk_select} *)
   val mk_store : context -> Expr.expr -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Create a constant array.
-      
-      The resulting term is an array, such that a [select]on an arbitrary index 
+
+      The resulting term is an array, such that a [select]on an arbitrary index
       produces the value [v].
       {!Z3Array.mk_sort}
       {!mk_select} *)
   val mk_const_array : context -> Sort.sort -> Expr.expr -> Expr.expr
 
   (** Maps f on the argument arrays.
-      
+
       Eeach element of [args] must be of an array sort [[domain_i -> range_i]].
       The function declaration [f] must have type [ range_1 .. range_n -> range].
       [v] must have sort range. The sort of the result is [[domain_i -> range]].
@@ -836,12 +836,12 @@ sig
   val mk_map : context -> FuncDecl.func_decl -> Expr.expr list -> Expr.expr
 
   (** Access the array default value.
-      
-      Produces the default range value, for arrays that can be represented as 
+
+      Produces the default range value, for arrays that can be represented as
       finite maps with a default range value. *)
   val mk_term_array : context -> Expr.expr -> Expr.expr
 
-  (** Create array extensionality index given two arrays with the same sort. 
+  (** Create array extensionality index given two arrays with the same sort.
 
       The meaning is given by the axiom:
           (=> (= (select A (array-ext A B)) (select B (array-ext A B))) (= A B)) *)
@@ -928,9 +928,9 @@ sig
   val is_relation : Expr.expr -> bool
 
   (** Indicates whether the term is an relation store
-      
+
       Insert a record into a relation.
-      The function takes [n+1] arguments, where the first argument is the relation and the remaining [n] elements 
+      The function takes [n+1] arguments, where the first argument is the relation and the remaining [n] elements
       correspond to the [n] columns of the relation. *)
   val is_store : Expr.expr -> bool
 
@@ -943,7 +943,7 @@ sig
   (** Indicates whether the term is a relational join *)
   val is_join : Expr.expr -> bool
 
-  (** Indicates whether the term is the union or convex hull of two relations. 
+  (** Indicates whether the term is the union or convex hull of two relations.
       The function takes two arguments. *)
   val is_union : Expr.expr -> bool
 
@@ -956,29 +956,29 @@ sig
   val is_project : Expr.expr -> bool
 
   (** Indicates whether the term is a relation filter
-      
+
       Filter (restrict) a relation with respect to a predicate.
-      The first argument is a relation. 
+      The first argument is a relation.
       The second argument is a predicate with free de-Brujin indices
       corresponding to the columns of the relation.
       So the first column in the relation has index 0. *)
   val is_filter : Expr.expr -> bool
 
   (** Indicates whether the term is an intersection of a relation with the negation of another.
-      
+
       Intersect the first relation with respect to negation
       of the second relation (the function takes two arguments).
       Logically, the specification can be described by a function
-      
+
       target = filter_by_negation(pos, neg, columns)
-      
+
       where columns are pairs c1, d1, .., cN, dN of columns from pos and neg, such that
       target are elements in ( x : expr ) in pos, such that there is no y in neg that agrees with
       ( x : expr ) on the columns c1, d1, .., cN, dN. *)
   val is_negation_filter : Expr.expr -> bool
 
   (** Indicates whether the term is the renaming of a column in a relation
-      
+
       The function takes one argument.
       The parameters contain the renaming as a cycle. *)
   val is_rename : Expr.expr -> bool
@@ -987,18 +987,18 @@ sig
   val is_complement : Expr.expr -> bool
 
   (** Indicates whether the term is a relational select
-      
+
       Check if a record is an element of the relation.
       The function takes [n+1] arguments, where the first argument is a relation,
       and the remaining [n] arguments correspond to a record. *)
   val is_select : Expr.expr -> bool
 
   (** Indicates whether the term is a relational clone (copy)
-      
-      Create a fresh copy (clone) of a relation. 
+
+      Create a fresh copy (clone) of a relation.
       The function is logically the identity, but
-      in the context of a register machine allows 
-      for terms of kind {!is_union} 
+      in the context of a register machine allows
+      for terms of kind {!is_union}
       to perform destructive updates to the first argument. *)
   val is_clone : Expr.expr -> bool
 
@@ -1019,24 +1019,24 @@ sig
 
     (** The number of fields of the constructor. *)
     val get_num_fields : constructor -> int
-      
+
     (** The function declaration of the constructor. *)
     val get_constructor_decl : constructor -> FuncDecl.func_decl
 
     (** The function declaration of the tester. *)
     val get_tester_decl : constructor -> FuncDecl.func_decl
-      
+
     (** The function declarations of the accessors *)
     val get_accessor_decls : constructor -> FuncDecl.func_decl list
   end
 
   (** Create a datatype constructor.
-      if the corresponding sort reference is 0, then the value in sort_refs should be an index 
+      if the corresponding sort reference is 0, then the value in sort_refs should be an index
       referring to one of the recursive datatypes that is declared. *)
   val mk_constructor : context -> Symbol.symbol -> Symbol.symbol -> Symbol.symbol list -> Sort.sort option list -> int list -> Constructor.constructor
 
   (** Create a datatype constructor.
-      if the corresponding sort reference is 0, then the value in sort_refs should be an index 
+      if the corresponding sort reference is 0, then the value in sort_refs should be an index
       referring to one of the recursive datatypes that is declared. *)
   val mk_constructor_s : context -> string -> Symbol.symbol -> Symbol.symbol list -> Sort.sort option list -> int list -> Constructor.constructor
 
@@ -1057,7 +1057,7 @@ sig
 
   (** The constructors. *)
   val get_constructors : Sort.sort -> FuncDecl.func_decl list
-    
+
   (** The recognizers. *)
   val get_recognizers : Sort.sort -> FuncDecl.func_decl list
 
@@ -1127,7 +1127,7 @@ end
 (** Functions to manipulate Tuple expressions *)
 module Tuple :
 sig
-  (** Create a new tuple sort. *)    
+  (** Create a new tuple sort. *)
   val mk_sort : context -> Symbol.symbol -> Symbol.symbol list -> Sort.sort list -> Sort.sort
 
   (**  The constructor function of the tuple. *)
@@ -1146,7 +1146,7 @@ sig
   (** Integer Arithmetic *)
   module Integer :
   sig
-    (** Create a new integer sort. *)      
+    (** Create a new integer sort. *)
     val mk_sort : context -> Sort.sort
 
     (** Retrieve the int value. *)
@@ -1158,7 +1158,7 @@ sig
     (** Returns a string representation of a numeral. *)
     val numeral_to_string : Expr.expr -> string
 
-    (** Creates an integer constant. *)        
+    (** Creates an integer constant. *)
     val mk_const : context -> Symbol.symbol -> Expr.expr
 
     (** Creates an integer constant. *)
@@ -1179,21 +1179,21 @@ sig
         @return A Term with the given value and sort Integer *)
     val mk_numeral_i : context -> int -> Expr.expr
 
-    (** Coerce an integer to a real.    
-        
+    (** Coerce an integer to a real.
+
         There is also a converse operation exposed. It follows the semantics prescribed by the SMT-LIB standard.
-        
+
         You can take the floor of a real by creating an auxiliary integer Term [k] and
         and asserting [MakeInt2Real(k) <= t1 < MkInt2Real(k)+1].
         The argument must be of integer sort. *)
     val mk_int2real : context -> Expr.expr -> Expr.expr
 
-    (**   Create an n-bit bit-vector from an integer argument.  
-          
-          NB. This function is essentially treated as uninterpreted. 
+    (**   Create an n-bit bit-vector from an integer argument.
+
+          NB. This function is essentially treated as uninterpreted.
           So you cannot expect Z3 to precisely reflect the semantics of this function
           when solving constraints with this function.
-          
+
           The argument must be of integer sort. *)
     val mk_int2bv : context -> int -> Expr.expr -> Expr.expr
   end
@@ -1201,7 +1201,7 @@ sig
   (** Real Arithmetic *)
   module Real :
   sig
-    (** Create a real sort. *)    
+    (** Create a real sort. *)
     val mk_sort : context -> Sort.sort
 
     (** The numerator of a rational numeral. *)
@@ -1213,7 +1213,7 @@ sig
     (** Get a ratio from a real numeral *)
     val get_ratio : Expr.expr -> Ratio.ratio
 
-    (** Returns a string representation in decimal notation. 
+    (** Returns a string representation in decimal notation.
         The result has at most as many decimal places as indicated by the int argument.*)
     val to_decimal_string : Expr.expr-> int -> string
 
@@ -1226,7 +1226,7 @@ sig
     (** Creates a real constant. *)
     val mk_const_s : context -> string -> Expr.expr
 
-    (** Create a real numeral from a fraction.       
+    (** Create a real numeral from a fraction.
         @return A Term with rational value and sort Real
         {!mk_numeral_s} *)
     val mk_numeral_nd : context -> int -> int -> Expr.expr
@@ -1247,26 +1247,26 @@ sig
         The semantics of this function follows the SMT-LIB standard for the function to_int.
         The argument must be of real sort. *)
     val mk_real2int : context -> Expr.expr -> Expr.expr
-      
+
     (** Algebraic Numbers *)
     module AlgebraicNumber :
     sig
-      (** Return a upper bound for a given real algebraic number. 
+      (** Return a upper bound for a given real algebraic number.
           The interval isolating the number is smaller than 1/10^precision.
-          {!is_algebraic_number}   
+          {!is_algebraic_number}
           @return A numeral Expr of sort Real *)
       val to_upper : Expr.expr -> int -> Expr.expr
-        
-      (** Return a lower bound for the given real algebraic number. 
+
+      (** Return a lower bound for the given real algebraic number.
           The interval isolating the number is smaller than 1/10^precision.
           {!is_algebraic_number}
           @return A numeral Expr of sort Real *)
       val to_lower : Expr.expr -> int -> Expr.expr
-        
-      (** Returns a string representation in decimal notation. 
+
+      (** Returns a string representation in decimal notation.
           The result has at most as many decimal places as the int argument provided.*)
       val to_decimal_string : Expr.expr -> int -> string
-        
+
       (** Returns a string representation of a numeral. *)
       val numeral_to_string : Expr.expr -> string
     end
@@ -1335,34 +1335,34 @@ sig
   (** Indicates whether the term is an algebraic number *)
   val is_algebraic_number : Expr.expr -> bool
 
-  (** Create an expression representing [t[0] + t[1] + ...]. *)    
+  (** Create an expression representing [t[0] + t[1] + ...]. *)
   val mk_add : context -> Expr.expr list -> Expr.expr
 
-  (** Create an expression representing [t[0] * t[1] * ...]. *)    
+  (** Create an expression representing [t[0] * t[1] * ...]. *)
   val mk_mul : context -> Expr.expr list -> Expr.expr
 
-  (** Create an expression representing [t[0] - t[1] - ...]. *)    
+  (** Create an expression representing [t[0] - t[1] - ...]. *)
   val mk_sub : context -> Expr.expr list -> Expr.expr
 
-  (** Create an expression representing [-t]. *)    
+  (** Create an expression representing [-t]. *)
   val mk_unary_minus : context -> Expr.expr -> Expr.expr
 
-  (** Create an expression representing [t1 / t2]. *)    
+  (** Create an expression representing [t1 / t2]. *)
   val mk_div : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Create an expression representing [t1 ^ t2]. *)    
+  (** Create an expression representing [t1 ^ t2]. *)
   val mk_power : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Create an expression representing [t1 < t2] *)    
+  (** Create an expression representing [t1 < t2] *)
   val mk_lt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Create an expression representing [t1 <= t2] *)    
+  (** Create an expression representing [t1 <= t2] *)
   val mk_le : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Create an expression representing [t1 > t2] *)    
+  (** Create an expression representing [t1 > t2] *)
   val mk_gt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Create an expression representing [t1 >= t2] *)    
+  (** Create an expression representing [t1 >= t2] *)
   val mk_ge : context -> Expr.expr -> Expr.expr -> Expr.expr
 end
 
@@ -1517,22 +1517,22 @@ sig
   (** Indicates whether the term is a bit-vector rotate right (extended)
       Similar to Z3_OP_ROTATE_RIGHT, but it is a binary operator instead of a parametric one. *)
   val is_bv_rotaterightextended : Expr.expr -> bool
-    
+
   (** Indicates whether the term is a coercion from bit-vector to integer
-      This function is not supported by the decision procedures. Only the most 
+      This function is not supported by the decision procedures. Only the most
       rudimentary simplification rules are applied to this function. *)
   val is_int2bv : Expr.expr -> bool
 
   (** Indicates whether the term is a coercion from integer to bit-vector
-      This function is not supported by the decision procedures. Only the most 
+      This function is not supported by the decision procedures. Only the most
       rudimentary simplification rules are applied to this function. *)
   val is_bv2int : Expr.expr -> bool
 
   (** Indicates whether the term is a bit-vector carry
-      Compute the carry bit in a full-adder.  The meaning is given by the 
+      Compute the carry bit in a full-adder.  The meaning is given by the
       equivalence (carry l1 l2 l3) <=> (or (and l1 l2) (and l1 l3) (and l2 l3))) *)
   val is_bv_carry : Expr.expr -> bool
-    
+
   (** Indicates whether the term is a bit-vector ternary XOR
       The meaning is given by the equivalence (xor3 l1 l2 l3) <=> (xor (xor l1 l2) l3) *)
   val is_bv_xor3 : Expr.expr -> bool
@@ -1542,7 +1542,7 @@ sig
 
   (**  Retrieve the int value. *)
   val get_int : Expr.expr -> int
-    
+
   (** Returns a string representation of a numeral. *)
   val numeral_to_string : Expr.expr -> string
 
@@ -1605,7 +1605,7 @@ sig
   val mk_mul : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Unsigned division.
-      
+
       It is defined as the floor of [t1/t2] if \c t2 is
       different from zero. If [t2] is zero, then the result
       is undefined.
@@ -1613,7 +1613,7 @@ sig
   val mk_udiv : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Signed division.
-      
+
       It is defined in the following way:
 
       - The \c floor of [t1/t2] if \c t2 is different from zero, and [t1*t2 >= 0].
@@ -1625,14 +1625,14 @@ sig
   val mk_sdiv : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Unsigned remainder.
-      
-      It is defined as [t1 - (t1 /u t2) * t2], where [/u] represents unsigned division.       
+
+      It is defined as [t1 - (t1 /u t2) * t2], where [/u] represents unsigned division.
       If [t2] is zero, then the result is undefined.
       The arguments must have the same bit-vector sort. *)
   val mk_urem : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Signed remainder.
-      
+
       It is defined as [t1 - (t1 /s t2) * t2], where [/s] represents signed division.
       The most significant bit (sign) of the result is equal to the most significant bit of \c t1.
 
@@ -1641,63 +1641,63 @@ sig
   val mk_srem : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Two's complement signed remainder (sign follows divisor).
-      
+
       If [t2] is zero, then the result is undefined.
       The arguments must have the same bit-vector sort. *)
   val mk_smod : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Unsigned less-than
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_ult : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Two's complement signed less-than
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_slt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Unsigned less-than or equal to.
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_ule : context -> Expr.expr -> Expr.expr -> Expr.expr
-    
+
   (** Two's complement signed less-than or equal to.
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_sle : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Unsigned greater than or equal to.
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_uge : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Two's complement signed greater than or equal to.
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_sge : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Unsigned greater-than.
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_ugt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Two's complement signed greater-than.
-      
+
       The arguments must have the same bit-vector sort. *)
   val mk_sgt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Bit-vector concatenation.
-      
+
       The arguments must have a bit-vector sort.
-      @return 
-      The result is a bit-vector of size [n1+n2], where [n1] ([n2]) 
+      @return
+      The result is a bit-vector of size [n1+n2], where [n1] ([n2])
       is the size of [t1] ([t2]). *)
   val mk_concat : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Bit-vector extraction.
-      
+
       Extract the bits between two limits from a bitvector of
-      size [m] to yield a new bitvector of size [n], where 
+      size [m] to yield a new bitvector of size [n], where
       [n = high - low + 1]. *)
   val mk_extract : context -> int -> int -> Expr.expr -> Expr.expr
 
@@ -1713,38 +1713,38 @@ sig
       bitvector of size [m+i], where \c m is the size of the
       given bit-vector. *)
   val mk_zero_ext : context -> int -> Expr.expr -> Expr.expr
-    
+
   (** Bit-vector repetition. *)
   val mk_repeat : context -> int -> Expr.expr -> Expr.expr
 
   (** Shift left.
 
       It is equivalent to multiplication by [2^x] where \c x is the value of third argument.
-      
-      NB. The semantics of shift operations varies between environments. This 
-      definition does not necessarily capture directly the semantics of the 
+
+      NB. The semantics of shift operations varies between environments. This
+      definition does not necessarily capture directly the semantics of the
       programming language or assembly architecture you are modeling.*)
   val mk_shl : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Logical shift right
-      
+
       It is equivalent to unsigned division by [2^x] where \c x is the value of the third argument.
 
-      NB. The semantics of shift operations varies between environments. This 
-      definition does not necessarily capture directly the semantics of the 
+      NB. The semantics of shift operations varies between environments. This
+      definition does not necessarily capture directly the semantics of the
       programming language or assembly architecture you are modeling.
 
       The arguments must have a bit-vector sort. *)
   val mk_lshr : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Arithmetic shift right
-      
+
       It is like logical shift right except that the most significant
       bits of the result always copy the most significant bit of the
       second argument.
 
-      NB. The semantics of shift operations varies between environments. This 
-      definition does not necessarily capture directly the semantics of the 
+      NB. The semantics of shift operations varies between environments. This
+      definition does not necessarily capture directly the semantics of the
       programming language or assembly architecture you are modeling.
 
       The arguments must have a bit-vector sort. *)
@@ -1754,70 +1754,70 @@ sig
       Rotate bits of \c t to the left \c i times. *)
   val mk_rotate_left : context -> int -> Expr.expr -> Expr.expr
 
-  (** Rotate Right.      
+  (** Rotate Right.
       Rotate bits of \c t to the right \c i times.*)
   val mk_rotate_right : context -> int -> Expr.expr -> Expr.expr
 
-  (** Rotate Left.     
+  (** Rotate Left.
       Rotate bits of the second argument to the left.*)
   val mk_ext_rotate_left : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Rotate Right.     
+  (** Rotate Right.
       Rotate bits of the second argument to the right. *)
   val mk_ext_rotate_right : context -> Expr.expr -> Expr.expr -> Expr.expr
 
-  (** Create an integer from the bit-vector argument 
-      
-      If \c is_signed is false, then the bit-vector \c t1 is treated as unsigned. 
-      So the result is non-negative and in the range [[0..2^N-1]], where 
+  (** Create an integer from the bit-vector argument
+
+      If \c is_signed is false, then the bit-vector \c t1 is treated as unsigned.
+      So the result is non-negative and in the range [[0..2^N-1]], where
       N are the number of bits in the argument.
       If \c is_signed is true, \c t1 is treated as a signed bit-vector.
-      
-      NB. This function is essentially treated as uninterpreted. 
+
+      NB. This function is essentially treated as uninterpreted.
       So you cannot expect Z3 to precisely reflect the semantics of this function
       when solving constraints with this function.*)
   val mk_bv2int : context -> Expr.expr -> bool -> Expr.expr
-    
+
   (** Create a predicate that checks that the bit-wise addition does not overflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_add_no_overflow : context -> Expr.expr -> Expr.expr -> bool -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise addition does not underflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_add_no_underflow : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise subtraction does not overflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_sub_no_overflow : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise subtraction does not underflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_sub_no_underflow : context -> Expr.expr -> Expr.expr -> bool -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise signed division does not overflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_sdiv_no_overflow : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise negation does not overflow.
-      
-      The arguments must be of bit-vector sort. *)      
+
+      The arguments must be of bit-vector sort. *)
   val mk_neg_no_overflow : context -> Expr.expr -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise multiplication does not overflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_mul_no_overflow : context -> Expr.expr -> Expr.expr -> bool -> Expr.expr
 
   (** Create a predicate that checks that the bit-wise multiplication does not underflow.
-      
+
       The arguments must be of bit-vector sort. *)
   val mk_mul_no_underflow : context -> Expr.expr -> Expr.expr -> Expr.expr
-    
+
   (** Create a bit-vector numeral. *)
   val mk_numeral : context -> string -> int -> Expr.expr
 end
@@ -1826,7 +1826,7 @@ end
 module FloatingPoint :
 sig
 
-  (** Rounding Modes *)    
+  (** Rounding Modes *)
   module RoundingMode :
   sig
     (** Create the RoundingMode sort. *)
@@ -1837,47 +1837,47 @@ sig
 
     (** Create a numeral of RoundingMode sort which represents the NearestTiesToEven rounding mode. *)
     val mk_round_nearest_ties_to_even : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the NearestTiesToEven rounding mode. *)
     val mk_rne : context -> Expr.expr
 
     (** Create a numeral of RoundingMode sort which represents the NearestTiesToAway rounding mode. *)
     val mk_round_nearest_ties_to_away : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the NearestTiesToAway rounding mode. *)
     val mk_rna : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the TowardPositive rounding mode. *)
     val mk_round_toward_positive : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the TowardPositive rounding mode. *)
     val mk_rtp : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the TowardNegative rounding mode. *)
     val mk_round_toward_negative : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the TowardNegative rounding mode. *)
     val mk_rtn : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the TowardZero rounding mode. *)
     val mk_round_toward_zero : context -> Expr.expr
-      
+
     (** Create a numeral of RoundingMode sort which represents the TowardZero rounding mode. *)
     val mk_rtz : context -> Expr.expr
   end
 
   (** Create a FloatingPoint sort. *)
   val mk_sort : context -> int -> int -> Sort.sort
-    
-  (** Create the half-precision (16-bit) FloatingPoint sort.*) 
+
+  (** Create the half-precision (16-bit) FloatingPoint sort.*)
   val mk_sort_half : context -> Sort.sort
-    
+
   (** Create the half-precision (16-bit) FloatingPoint sort. *)
   val mk_sort_16 : context -> Sort.sort
 
   (** Create the single-precision (32-bit) FloatingPoint sort.*)
   val mk_sort_single : context -> Sort.sort
-    
+
   (** Create the single-precision (32-bit) FloatingPoint sort. *)
   val mk_sort_32 : context -> Sort.sort
 
@@ -1886,7 +1886,7 @@ sig
 
   (** Create the double-precision (64-bit) FloatingPoint sort. *)
   val mk_sort_64 : context -> Sort.sort
-    
+
   (** Create the quadruple-precision (128-bit) FloatingPoint sort. *)
   val mk_sort_quadruple : context -> Sort.sort
 
@@ -1902,11 +1902,11 @@ sig
   (** Create a floating-point zero of a given FloatingPoint sort. *)
   val mk_zero : context -> Sort.sort -> bool -> Expr.expr
 
-  (** Create an expression of FloatingPoint sort from three bit-vector expressions. 
+  (** Create an expression of FloatingPoint sort from three bit-vector expressions.
 
       This is the operator named `fp' in the SMT FP theory definition.
-      Note that \c sign is required to be a bit-vector of size 1. Significand and exponent 
-      are required to be greater than 1 and 2 respectively. The FloatingPoint sort 
+      Note that \c sign is required to be a bit-vector of size 1. Significand and exponent
+      are required to be greater than 1 and 2 respectively. The FloatingPoint sort
       of the resulting expression is automatically determined from the bit-vector sizes
       of the arguments. *)
   val mk_fp : context -> Expr.expr -> Expr.expr -> Expr.expr -> Expr.expr
@@ -1919,16 +1919,16 @@ sig
 
   (** Create a numeral of FloatingPoint sort from a signed integer. *)
   val mk_numeral_i : context -> int -> Sort.sort -> Expr.expr
-    
+
   (** Create a numeral of FloatingPoint sort from a sign bit and two integers. *)
   val mk_numeral_i_u : context -> bool -> int -> int -> Sort.sort -> Expr.expr
 
   (** Create a numeral of FloatingPoint sort from a string *)
   val mk_numeral_s : context -> string -> Sort.sort -> Expr.expr
-    
+
   (** Indicates whether the terms is of floating-point sort. *)
   val is_fp : Expr.expr -> bool
-    
+
 
   (** Indicates whether an expression is a floating-point abs expression *)
   val is_abs : Expr.expr -> bool
@@ -1938,7 +1938,7 @@ sig
 
   (** Indicates whether an expression is a floating-point add expression *)
   val is_add : Expr.expr -> bool
-    
+
   (** Indicates whether an expression is a floating-point sub expression *)
   val is_sub : Expr.expr -> bool
 
@@ -1995,7 +1995,7 @@ sig
 
   (** Indicates whether an expression is a floating-point is_nan expression *)
   val is_is_nan : Expr.expr -> bool
-    
+
   (** Indicates whether an expression is a floating-point is_negative expression *)
   val is_is_negative : Expr.expr -> bool
 
@@ -2050,16 +2050,16 @@ sig
 
   (** Floating-point fused multiply-add. *)
   val mk_fma : context -> Expr.expr -> Expr.expr -> Expr.expr -> Expr.expr -> Expr.expr
-    
+
   (** Floating-point square root *)
   val mk_sqrt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Floating-point remainder *)
   val mk_rem : context -> Expr.expr -> Expr.expr -> Expr.expr
-    
-  (** Floating-point roundToIntegral. 
 
-      Rounds a floating-point number to the closest integer, 
+  (** Floating-point roundToIntegral.
+
+      Rounds a floating-point number to the closest integer,
       again represented as a floating-point number. *)
   val mk_round_to_integral : context -> Expr.expr -> Expr.expr -> Expr.expr
 
@@ -2068,16 +2068,16 @@ sig
 
   (** Maximum of floating-point numbers. *)
   val mk_max : context -> Expr.expr -> Expr.expr -> Expr.expr
-    
+
   (** Floating-point less than or equal. *)
   val mk_leq : context -> Expr.expr -> Expr.expr -> Expr.expr
-    
+
   (** Floating-point less than. *)
   val mk_lt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
   (** Floating-point greater than or equal. *)
   val mk_geq : context -> Expr.expr -> Expr.expr -> Expr.expr
-    
+
   (** Floating-point greater than. *)
   val mk_gt : context -> Expr.expr -> Expr.expr -> Expr.expr
 
@@ -2122,27 +2122,27 @@ sig
 
   (** C1onversion of a floating-point term into an unsigned bit-vector. *)
   val mk_to_ubv : context -> Expr.expr -> Expr.expr -> int -> Expr.expr
-    
+
   (** Conversion of a floating-point term into a signed bit-vector. *)
   val mk_to_sbv : context -> Expr.expr -> Expr.expr -> int -> Expr.expr
 
   (** Conversion of a floating-point term into a real-numbered term. *)
   val mk_to_real : context -> Expr.expr -> Expr.expr
-    
+
   (** Retrieves the number of bits reserved for the exponent in a FloatingPoint sort. *)
   val get_ebits : context -> Sort.sort -> int
 
   (** Retrieves the number of bits reserved for the significand in a FloatingPoint sort. *)
   val get_sbits : context -> Sort.sort -> int
-    
+
   (** Retrieves the sign of a floating-point literal. *)
   val get_numeral_sign : context -> Expr.expr -> bool * int
 
   (** Return the significand value of a floating-point numeral as a string. *)
   val get_numeral_significand_string : context -> Expr.expr -> string
 
-  (** Return the significand value of a floating-point numeral as a uint64. 
-      Remark: This function extracts the significand bits, without the 
+  (** Return the significand value of a floating-point numeral as a uint64.
+      Remark: This function extracts the significand bits, without the
       hidden bit or normalization. Throws an exception if the
       significand does not fit into a uint64. *)
   val get_numeral_significand_uint : context -> Expr.expr -> bool * int
@@ -2152,7 +2152,7 @@ sig
 
   (** Return the exponent value of a floating-point numeral as a signed integer *)
   val get_numeral_exponent_int : context -> Expr.expr -> bool * int
-    
+
   (** Conversion of a floating-point term into a bit-vector term in IEEE 754-2008 format. *)
   val mk_to_ieee_bv : context -> Expr.expr -> Expr.expr
 
@@ -2176,13 +2176,13 @@ sig
   (** Indicates whether the term is a proof for a fact (tagged as goal) asserted by the user. *)
   val is_goal : Expr.expr -> bool
 
-  (** Indicates whether the term is a binary equivalence modulo namings. 
+  (** Indicates whether the term is a binary equivalence modulo namings.
       This binary predicate is used in proof terms.
       It captures equisatisfiability and equivalence modulo renamings. *)
   val is_oeq : Expr.expr -> bool
 
   (** Indicates whether the term is proof via modus ponens
-      
+
       Given a proof for p and a proof for (implies p q), produces a proof for q.
       T1: p
       T2: (implies p q)
@@ -2191,14 +2191,14 @@ sig
   val is_modus_ponens : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for (R t t), where R is a reflexive relation.
-      This proof object has no antecedents. 
-      The only reflexive relations that are used are 
+      This proof object has no antecedents.
+      The only reflexive relations that are used are
       equivalence modulo namings, equality and equivalence.
       That is, R is either '~', '=' or 'iff'. *)
   val is_reflexivity : Expr.expr -> bool
 
   (** Indicates whether the term is proof by symmetricity of a relation
-      
+
       Given an symmetric relation R and a proof for (R t s), produces a proof for (R s t).
       T1: (R t s)
       [symmetry T1]: (R s t)
@@ -2206,51 +2206,51 @@ sig
   val is_symmetry : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by transitivity of a relation
-      
-      Given a transitive relation R, and proofs for (R t s) and (R s u), produces a proof 
-      for (R t u). 
+
+      Given a transitive relation R, and proofs for (R t s) and (R s u), produces a proof
+      for (R t u).
       T1: (R t s)
       T2: (R s u)
       [trans T1 T2]: (R t u) *)
   val is_transitivity : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by condensed transitivity of a relation
-      
+
       Condensed transitivity proof. This proof object is only used if the parameter PROOF_MODE is 1.
-      It combines several symmetry and transitivity proofs. 
+      It combines several symmetry and transitivity proofs.
       Example:
       T1: (R a b)
       T2: (R c b)
       T3: (R c d)
-      [trans* T1 T2 T3]: (R a d)          
+      [trans* T1 T2 T3]: (R a d)
       R must be a symmetric and transitive relation.
-      
+
       Assuming that this proof object is a proof for (R s t), then
       a proof checker must check if it is possible to prove (R s t)
-      using the antecedents, symmetry and transitivity.  That is, 
+      using the antecedents, symmetry and transitivity.  That is,
       if there is a path from s to t, if we view every
       antecedent (R a b) as an edge between a and b. *)
   val is_Transitivity_star : Expr.expr -> bool
 
   (** Indicates whether the term is a monotonicity proof object.
-      
+
       T1: (R t_1 s_1)
       ...
       Tn: (R t_n s_n)
-      [monotonicity T1 ... Tn]: (R (f t_1 ... t_n) (f s_1 ... s_n))          
+      [monotonicity T1 ... Tn]: (R (f t_1 ... t_n) (f s_1 ... s_n))
       Remark: if t_i == s_i, then the antecedent Ti is suppressed.
       That is, reflexivity proofs are supressed to save space. *)
   val is_monotonicity : Expr.expr -> bool
 
-  (** Indicates whether the term is a quant-intro proof 
-      
+  (** Indicates whether the term is a quant-intro proof
+
       Given a proof for (~ p q), produces a proof for (~ (forall (x) p) (forall (x) q)).
       T1: (~ p q)
       [quant-intro T1]: (~ (forall (x) p) (forall (x) q)) *)
   val is_quant_intro : Expr.expr -> bool
 
-  (** Indicates whether the term is a distributivity proof object.  
-      
+  (** Indicates whether the term is a distributivity proof object.
+
       Given that f (= or) distributes over g (= and), produces a proof for
       (= (f a (g c d))
       (g (f a c) (f a d)))
@@ -2258,36 +2258,36 @@ sig
       (= (f (g a b) (g c d))
       (g (f a c) (f a d) (f b c) (f b d)))
       where each f and g can have arbitrary number of arguments.
-      
+
       This proof object has no antecedents.
-      Remark. This rule is used by the CNF conversion pass and 
+      Remark. This rule is used by the CNF conversion pass and
       instantiated by f = or, and g = and. *)
   val is_distributivity : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by elimination of AND
-      
+
       Given a proof for (and l_1 ... l_n), produces a proof for l_i
       T1: (and l_1 ... l_n)
       [and-elim T1]: l_i *)
   val is_and_elimination : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by eliminiation of not-or
-      
+
       Given a proof for (not (or l_1 ... l_n)), produces a proof for (not l_i).
       T1: (not (or l_1 ... l_n))
       [not-or-elim T1]: (not l_i)        *)
   val is_or_elimination : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by rewriting
-      
+
       A proof for a local rewriting step (= t s).
       The head function symbol of t is interpreted.
-      
+
       This proof object has no antecedents.
-      The conclusion of a rewrite rule is either an equality (= t s), 
+      The conclusion of a rewrite rule is either an equality (= t s),
       an equivalence (iff t s), or equi-satisfiability (~ t s).
       Remark: if f is bool, then = is iff.
-      
+
       Examples:
       (= (+ ( x : expr ) 0) x)
       (= (+ ( x : expr ) 1 2) (+ 3 x))
@@ -2295,7 +2295,7 @@ sig
   val is_rewrite : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by rewriting
-      
+
       A proof for rewriting an expression t into an expression s.
       This proof object is used if the parameter PROOF_MODE is 1.
       This proof object can have n antecedents.
@@ -2308,49 +2308,49 @@ sig
   val is_rewrite_star : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for pulling quantifiers out.
-      
+
       A proof for (iff (f (forall (x) q(x)) r) (forall (x) (f (q x) r))). This proof object has no antecedents. *)
   val is_pull_quant : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for pulling quantifiers out.
-      
-      A proof for (iff P Q) where Q is in prenex normal form. 
-      This proof object is only used if the parameter PROOF_MODE is 1.       
+
+      A proof for (iff P Q) where Q is in prenex normal form.
+      This proof object is only used if the parameter PROOF_MODE is 1.
       This proof object has no antecedents *)
   val is_pull_quant_star : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for pushing quantifiers in.
-      
+
       A proof for:
       (iff (forall (x_1 ... x_m) (and p_1[x_1 ... x_m] ... p_n[x_1 ... x_m]))
       (and (forall (x_1 ... x_m) p_1[x_1 ... x_m])
-      ... 
-      (forall (x_1 ... x_m) p_n[x_1 ... x_m])))               
+      ...
+      (forall (x_1 ... x_m) p_n[x_1 ... x_m])))
       This proof object has no antecedents *)
   val is_push_quant : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for elimination of unused variables.
-      
+
       A proof for (iff (forall (x_1 ... x_n y_1 ... y_m) p[x_1 ... x_n])
-      (forall (x_1 ... x_n) p[x_1 ... x_n])) 
-      
+      (forall (x_1 ... x_n) p[x_1 ... x_n]))
+
       It is used to justify the elimination of unused variables.
       This proof object has no antecedents. *)
   val is_elim_unused_vars : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for destructive equality resolution
-      
+
       A proof for destructive equality resolution:
       (iff (forall (x) (or (not (= ( x : expr ) t)) P[x])) P[t])
       if ( x : expr ) does not occur in t.
-      
+
       This proof object has no antecedents.
-      
+
       Several variables can be eliminated simultaneously. *)
   val is_der : Expr.expr -> bool
-    
+
   (** Indicates whether the term is a proof for quantifier instantiation
-      
+
       A proof of (or (not (forall (x) (P x))) (P a)) *)
   val is_quant_inst : Expr.expr -> bool
 
@@ -2359,17 +2359,17 @@ sig
   val is_hypothesis : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by lemma
-      
+
       T1: false
       [lemma T1]: (or (not l_1) ... (not l_n))
-      
+
       This proof object has one antecedent: a hypothetical proof for false.
       It converts the proof in a proof for (or (not l_1) ... (not l_n)),
       when T1 contains the hypotheses: l_1, ..., l_n. *)
   val is_lemma : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by unit resolution
-      
+
       T1:      (or l_1 ... l_n l_1' ... l_m')
       T2:      (not l_1)
       ...
@@ -2378,31 +2378,31 @@ sig
   val is_unit_resolution : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by iff-true
-      
+
       T1: p
       [iff-true T1]: (iff p true) *)
   val is_iff_true : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by iff-false
-      
+
       T1: (not p)
       [iff-false T1]: (iff p false) *)
   val is_iff_false : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by commutativity
-      
+
       [comm]: (= (f a b) (f b a))
-      
+
       f is a commutative operator.
-      
+
       This proof object has no antecedents.
       Remark: if f is bool, then = is iff. *)
   val is_commutativity : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for Tseitin-like axioms
-      
+
       Proof object used to justify Tseitin's like axioms:
-      
+
       (or (not (and p q)) p)
       (or (not (and p q)) q)
       (or (not (and p q r)) p)
@@ -2423,7 +2423,7 @@ sig
       (or (ite a b c) a (not c))
       (or (not (not a)) (not a))
       (or (not a) a)
-      
+
       This proof object has no antecedents.
       Note: all axioms are propositional tautologies.
       Note also that 'and' and 'or' can take multiple arguments.
@@ -2433,56 +2433,56 @@ sig
   val is_def_axiom : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for introduction of a name
-      
+
       Introduces a name for a formula/term.
       Suppose e is an expression with free variables x, and def-intro
       introduces the name n(x). The possible cases are:
-      
+
       When e is of Boolean type:
       [def-intro]: (and (or n (not e)) (or (not n) e))
-      
+
       or:
       [def-intro]: (or (not n) e)
       when e only occurs positively.
-      
+
       When e is of the form (ite cond th el):
       [def-intro]: (and (or (not cond) (= n th)) (or cond (= n el)))
-      
+
       Otherwise:
       [def-intro]: (= n e)        *)
   val is_def_intro : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for application of a definition
-      
+
       [apply-def T1]: F ~ n
       F is 'equivalent' to n, given that T1 is a proof that
       n is a name for F. *)
   val is_apply_def : Expr.expr -> bool
 
   (** Indicates whether the term is a proof iff-oeq
-      
+
       T1: (iff p q)
       [iff~ T1]: (~ p q) *)
   val is_iff_oeq : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for a positive NNF step
-      
+
       Proof for a (positive) NNF step. Example:
-      
+
       T1: (not s_1) ~ r_1
       T2: (not s_2) ~ r_2
       T3: s_1 ~ r_1'
       T4: s_2 ~ r_2'
       [nnf-pos T1 T2 T3 T4]: (~ (iff s_1 s_2)
       (and (or r_1 r_2') (or r_1' r_2)))
-      
+
       The negation normal form steps NNF_POS and NNF_NEG are used in the following cases:
       (a) When creating the NNF of a positive force quantifier.
       The quantifier is retained (unless the bound variables are eliminated).
       Example
-      T1: q ~ q_new 
+      T1: q ~ q_new
       [nnf-pos T1]: (~ (forall (x T) q) (forall (x T) q_new))
-      
+
       (b) When recursively creating NNF over Boolean formulas, where the top-level
       connective is changed during NNF conversion. The relevant Boolean connectives
       for NNF_POS are 'implies', 'iff', 'xor', 'ite'.
@@ -2491,9 +2491,9 @@ sig
   val is_nnf_pos : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for a negative NNF step
-      
+
       Proof for a (negative) NNF step. Examples:
-      
+
       T1: (not s_1) ~ r_1
       ...
       Tn: (not s_n) ~ r_n
@@ -2513,33 +2513,33 @@ sig
   val is_nnf_neg : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for (~ P Q) here Q is in negation normal form.
-      
+
       A proof for (~ P Q) where Q is in negation normal form.
-      
-      This proof object is only used if the parameter PROOF_MODE is 1.       
-      
+
+      This proof object is only used if the parameter PROOF_MODE is 1.
+
       This proof object may have n antecedents. Each antecedent is a PR_DEF_INTRO. *)
   val is_nnf_star : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for (~ P Q) where Q is in conjunctive normal form.
-      
+
       A proof for (~ P Q) where Q is in conjunctive normal form.
-      This proof object is only used if the parameter PROOF_MODE is 1.       
+      This proof object is only used if the parameter PROOF_MODE is 1.
       This proof object may have n antecedents. Each antecedent is a PR_DEF_INTRO.           *)
   val is_cnf_star : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for a Skolemization step
-      
-      Proof for: 
-      
+
+      Proof for:
+
       [sk]: (~ (not (forall ( x : expr ) (p ( x : expr ) y))) (not (p (sk y) y)))
       [sk]: (~ (exists ( x : expr ) (p ( x : expr ) y)) (p (sk y) y))
-      
+
       This proof object has no antecedents. *)
   val is_skolemize : Expr.expr -> bool
 
   (** Indicates whether the term is a proof by modus ponens for equi-satisfiability.
-      
+
       Modus ponens style rule for equi-satisfiability.
       T1: p
       T2: (~ p q)
@@ -2547,32 +2547,32 @@ sig
   val is_modus_ponens_oeq : Expr.expr -> bool
 
   (** Indicates whether the term is a proof for theory lemma
-      
+
       Generic proof for theory lemmas.
-      
+
       The theory lemma function comes with one or more parameters.
       The first parameter indicates the name of the theory.
       For the theory of arithmetic, additional parameters provide hints for
-      checking the theory lemma. 
+      checking the theory lemma.
       The hints for arithmetic are:
       - farkas - followed by rational coefficients. Multiply the coefficients to the
       inequalities in the lemma, add the (negated) inequalities and obtain a contradiction.
-      - triangle-eq - Indicates a lemma related to the equivalence:        
+      - triangle-eq - Indicates a lemma related to the equivalence:
       (iff (= t1 t2) (and (<= t1 t2) (<= t2 t1)))
       - gcd-test - Indicates an integer linear arithmetic lemma that uses a gcd test. *)
   val is_theory_lemma : Expr.expr -> bool
 end
 
-(** Goals 
+(** Goals
 
-    A goal (aka problem). A goal is essentially a 
+    A goal (aka problem). A goal is essentially a
     of formulas, that can be solved and/or transformed using
     tactics and solvers. *)
 module Goal :
 sig
-  type goal 
+  type goal
 
-  (** The precision of the goal. 
+  (** The precision of the goal.
 
       Goals can be transformed using over and under approximations.
       An under approximation is applied when the objective is to find a model for a given goal.
@@ -2593,11 +2593,11 @@ sig
 
   (** Adds the constraints to the given goal. *)
   val add : goal -> Expr.expr list -> unit
-    
+
   (** Indicates whether the goal contains `false'. *)
   val is_inconsistent : goal -> bool
-    
-  (** The depth of the goal.      
+
+  (** The depth of the goal.
       This tracks how many transformations were applied to it. *)
   val get_depth : goal -> int
 
@@ -2626,8 +2626,8 @@ sig
   val simplify : goal -> Params.params option -> goal
 
   (** Creates a new Goal.
-      
-      Note that the Context must have been created with proof generation support if 
+
+      Note that the Context must have been created with proof generation support if
       the fourth argument is set to true here. *)
   val mk_goal : context -> bool -> bool -> bool -> goal
 
@@ -2643,25 +2643,25 @@ end
     A Model contains interpretations (assignments) of constants and functions. *)
 module Model :
 sig
-  type model 
+  type model
 
-  (** Function interpretations 
+  (** Function interpretations
 
       A function interpretation is represented as a finite map and an 'else'.
-      Each entry in the finite map represents the value of a function given a set of arguments.   *)    
+      Each entry in the finite map represents the value of a function given a set of arguments.   *)
   module FuncInterp :
   sig
-    type func_interp 
-      
-    (** Function interpretations entries 
+    type func_interp
 
-        An Entry object represents an element in the finite map used to a function interpretation. *)  
+    (** Function interpretations entries
+
+        An Entry object represents an element in the finite map used to a function interpretation. *)
     module FuncEntry :
     sig
-      type func_entry 
+      type func_entry
 
       (** Return the (symbolic) value of this entry.
-      *)    
+      *)
       val get_value : func_entry -> Expr.expr
 
       (** The number of arguments of the entry.
@@ -2689,26 +2689,26 @@ sig
     (**   The arity of the function interpretation *)
     val get_arity : func_interp -> int
 
-    (**   A string representation of the function interpretation. *)    
+    (**   A string representation of the function interpretation. *)
     val to_string : func_interp -> string
   end
 
-  (** Retrieves the interpretation (the assignment) of a func_decl in the model. 
+  (** Retrieves the interpretation (the assignment) of a func_decl in the model.
       @return An expression if the function has an interpretation in the model, null otherwise. *)
   val get_const_interp : model -> FuncDecl.func_decl -> Expr.expr option
 
-  (** Retrieves the interpretation (the assignment) of an expression in the model. 
+  (** Retrieves the interpretation (the assignment) of an expression in the model.
       @return An expression if the constant has an interpretation in the model, null otherwise. *)
   val get_const_interp_e : model -> Expr.expr -> Expr.expr option
 
-  (** Retrieves the interpretation (the assignment) of a non-constant func_decl in the model. 
+  (** Retrieves the interpretation (the assignment) of a non-constant func_decl in the model.
       @return A FunctionInterpretation if the function has an interpretation in the model, null otherwise. *)
   val get_func_interp : model -> FuncDecl.func_decl -> FuncInterp.func_interp option
 
   (** The number of constant interpretations in the model. *)
   val get_num_consts : model -> int
 
-  (** The function declarations of the constants in the model. *)  
+  (** The function declarations of the constants in the model. *)
   val get_const_decls : model -> FuncDecl.func_decl list
 
   (** The number of function interpretations in the model. *)
@@ -2721,8 +2721,8 @@ sig
   val get_decls : model -> FuncDecl.func_decl list
 
   (** Evaluates an expression in the current model.
-      
-      This function may fail if the argument contains quantifiers, 
+
+      This function may fail if the argument contains quantifiers,
       is partial (MODEL_PARTIAL enabled), or if it is not well-sorted.
       In this case a [ModelEvaluationFailedException] is thrown.
   *)
@@ -2734,8 +2734,8 @@ sig
   (** The number of uninterpreted sorts that the model has an interpretation for. *)
   val get_num_sorts : model -> int
 
-  (** The uninterpreted sorts that the model has an interpretation for. 
-      
+  (** The uninterpreted sorts that the model has an interpretation for.
+
       Z3 also provides an intepretation for uninterpreted sorts used in a formula.
       The interpretation for a sort is a finite set of distinct values. We say this finite set is
       the "universe" of the sort.
@@ -2743,17 +2743,17 @@ sig
       {!sort_universe} *)
   val get_sorts : model -> Sort.sort list
 
-  (** The finite set of distinct values that represent the interpretation of a sort. 
+  (** The finite set of distinct values that represent the interpretation of a sort.
       {!get_sorts}
       @return A list of expressions, where each is an element of the universe of the sort *)
   val sort_universe : model -> Sort.sort -> Expr.expr list
-    
-  (** Conversion of models to strings. 
+
+  (** Conversion of models to strings.
       @return A string representation of the model. *)
   val to_string : model -> string
 end
 
-(** Probes 
+(** Probes
 
     Probes are used to inspect a goal (aka problem) and collect information that may be used to decide
     which solver and/or preprocessing step will be used.
@@ -2763,9 +2763,9 @@ end
 *)
 module Probe :
 sig
-  type probe 
+  type probe
 
-  (** Execute the probe over the goal. 
+  (** Execute the probe over the goal.
       @return A probe always produce a float value.
       "Boolean" probes return 0.0 for false, and a value different from 0.0 for true. *)
   val apply : probe -> Goal.goal -> float
@@ -2779,7 +2779,7 @@ sig
   (** Returns a string containing a description of the probe with the given name. *)
   val get_probe_description : context -> string -> string
 
-  (** Creates a new Probe. *) 
+  (** Creates a new Probe. *)
   val mk_probe : context -> string -> probe
 
   (** Create a probe that always evaluates to a float value. *)
@@ -2819,21 +2819,21 @@ end
 (** Tactics
 
     Tactics are the basic building block for creating custom solvers for specific problem domains.
-    The complete list of tactics may be obtained using [Context.get_num_tactics] 
+    The complete list of tactics may be obtained using [Context.get_num_tactics]
     and [Context.get_tactic_names].
     It may also be obtained using the command [(help-tactic)] in the SMT 2.0 front-end.
 *)
 module Tactic :
 sig
-  type tactic 
+  type tactic
 
-  (** Tactic application results 
-      
-      ApplyResult objects represent the result of an application of a 
+  (** Tactic application results
+
+      ApplyResult objects represent the result of an application of a
       tactic to a goal. It contains the subgoals that were produced. *)
   module ApplyResult :
   sig
-    type apply_result 
+    type apply_result
 
     (** The number of Subgoals. *)
     val get_num_subgoals : apply_result -> int
@@ -2844,8 +2844,8 @@ sig
     (** Retrieves a subgoal from the apply_result. *)
     val get_subgoal : apply_result -> int -> Goal.goal
 
-    (** Convert a model for a subgoal into a model for the original 
-        goal [g], that the ApplyResult was obtained from. 
+    (** Convert a model for a subgoal into a model for the original
+        goal [g], that the ApplyResult was obtained from.
         #return A model for [g] *)
     val convert_model : apply_result -> int -> Model.model -> Model.model
 
@@ -2871,7 +2871,7 @@ sig
   (** Returns a string containing a description of the tactic with the given name. *)
   val get_tactic_description : context -> string -> string
 
-  (** Creates a new Tactic. *)    
+  (** Creates a new Tactic. *)
   val mk_tactic : context -> string -> tactic
 
   (** Create a tactic that applies one tactic to a Goal and
@@ -2882,22 +2882,22 @@ sig
       if it fails then returns the result of another tactic applied to the Goal. *)
   val or_else : context -> tactic -> tactic -> tactic
 
-  (** Create a tactic that applies one tactic to a goal for some time (in milliseconds).    
-      
+  (** Create a tactic that applies one tactic to a goal for some time (in milliseconds).
+
       If the tactic does not terminate within the timeout, then it fails. *)
   val try_for : context -> tactic -> int -> tactic
 
-  (** Create a tactic that applies one tactic to a given goal if the probe 
-      evaluates to true. 
-      
+  (** Create a tactic that applies one tactic to a given goal if the probe
+      evaluates to true.
+
       If the probe evaluates to false, then the new tactic behaves like the [skip] tactic.  *)
   val when_ : context -> Probe.probe -> tactic -> tactic
 
-  (** Create a tactic that applies a tactic to a given goal if the probe 
+  (** Create a tactic that applies a tactic to a given goal if the probe
       evaluates to true and another tactic otherwise. *)
   val cond : context -> Probe.probe -> tactic -> tactic -> tactic
 
-  (** Create a tactic that keeps applying one tactic until the goal is not 
+  (** Create a tactic that keeps applying one tactic until the goal is not
       modified anymore or the maximum number of iterations is reached. *)
   val repeat : context -> tactic -> int -> tactic
 
@@ -2928,7 +2928,7 @@ sig
       to every subgoal produced by the first one. The subgoals are processed in parallel. *)
   val par_and_then : context -> tactic -> tactic -> tactic
 
-  (** Interrupt the execution of a Z3 procedure.        
+  (** Interrupt the execution of a Z3 procedure.
       This procedure can be used to interrupt: solvers, simplifiers and tactics. *)
   val interrupt : context -> unit
 end
@@ -2936,37 +2936,37 @@ end
 (** Objects that track statistical information. *)
 module Statistics :
 sig
-  type statistics 
-    
+  type statistics
+
   (** Statistical data is organized into pairs of \[Key, Entry\], where every
       Entry is either a floating point or integer value. *)
   module Entry :
   sig
     type statistics_entry
-      
+
     (** The key of the entry. *)
     val get_key : statistics_entry -> string
-      
+
     (** The int-value of the entry. *)
     val get_int : statistics_entry -> int
-      
+
     (** The float-value of the entry. *)
     val get_float : statistics_entry -> float
-      
+
     (** True if the entry is uint-valued. *)
     val is_int : statistics_entry -> bool
-      
+
     (** True if the entry is float-valued. *)
     val is_float : statistics_entry -> bool
-      
+
     (** The string representation of the the entry's value. *)
     val to_string_value : statistics_entry -> string
-      
+
     (** The string representation of the entry (key and value) *)
     val to_string : statistics_entry -> string
   end
 
-  (** A string representation of the statistical data. *)    
+  (** A string representation of the statistical data. *)
   val to_string : statistics -> string
 
   (** The number of statistical data. *)
@@ -2978,16 +2978,16 @@ sig
   (**   The statistical counters. *)
   val get_keys : statistics -> string list
 
-  (** The value of a particular statistical counter. *)        
+  (** The value of a particular statistical counter. *)
   val get : statistics -> string -> Entry.statistics_entry option
 end
 
 (** Solvers *)
 module Solver :
 sig
-  type solver 
+  type solver
   type status = UNSATISFIABLE | UNKNOWN | SATISFIABLE
-      
+
   val string_of_status : status -> string
 
   (** A string that describes all available solver parameters. *)
@@ -3017,7 +3017,7 @@ sig
       This removes all assertions from the solver. *)
   val reset : solver -> unit
 
-  (** Assert a constraint (or multiple) into the solver. *)        
+  (** Assert a constraint (or multiple) into the solver. *)
   val add : solver -> Expr.expr list -> unit
 
   (** * Assert multiple constraints (cs) into the solver, and track them (in the
@@ -3035,7 +3035,7 @@ sig
 
   (** * Assert a constraint (c) into the solver, and track it (in the unsat) core
       * using the Boolean constant p.
-      * 
+      *
       * This API is an alternative to {!check} with assumptions for
       * extracting unsat cores.
       * Both APIs can be used in the same solver. The unsat core will contain a
@@ -3052,26 +3052,26 @@ sig
   val get_assertions : solver -> Expr.expr list
 
   (** Checks whether the assertions in the solver are consistent or not.
-      
+
       {!Model}
       {!get_unsat_core}
       {!Proof}     *)
   val check : solver -> Expr.expr list -> status
 
   (** The model of the last [Check].
-      
+
       The result is [None] if [Check] was not invoked before,
       if its results was not [SATISFIABLE], or if model production is not enabled. *)
   val get_model : solver -> Model.model option
 
   (** The proof of the last [Check].
-      
+
       The result is [null] if [Check] was not invoked before,
       if its results was not [UNSATISFIABLE], or if proof production is disabled. *)
   val get_proof : solver -> Expr.expr option
 
   (** The unsat core of the last [Check].
-      
+
       The unsat core is a subset of [Assertions]
       The result is empty if [Check] was not invoked before,
       if its results was not [UNSATISFIABLE], or if core production is disabled. *)
@@ -3083,26 +3083,26 @@ sig
   (** Solver statistics. *)
   val get_statistics : solver -> Statistics.statistics
 
-  (** Creates a new (incremental) solver. 
-      
-      This solver also uses a set of builtin tactics for handling the first 
-      check-sat command, and check-sat commands that take more than a given 
-      number of milliseconds to be solved.  *)    
+  (** Creates a new (incremental) solver.
+
+      This solver also uses a set of builtin tactics for handling the first
+      check-sat command, and check-sat commands that take more than a given
+      number of milliseconds to be solved.  *)
   val mk_solver : context -> Symbol.symbol option -> solver
 
   (** Creates a new (incremental) solver.
-      {!mk_solver} *)        
+      {!mk_solver} *)
   val mk_solver_s : context -> string -> solver
 
   (** Creates a new (incremental) solver.  *)
   val mk_simple_solver : context -> solver
 
   (** Creates a solver that is implemented using the given tactic.
-      
+
       The solver supports the commands [Push] and [Pop], but it
       will always solve each check from scratch. *)
   val mk_solver_t : context -> Tactic.tactic -> solver
-        
+
   (** Create a clone of the current solver with respect to a context. *)
   val translate : solver -> context -> solver
 
@@ -3113,8 +3113,8 @@ end
 (** Fixedpoint solving *)
 module Fixedpoint :
 sig
-  type fixedpoint 
-    
+  type fixedpoint
+
   (** A string that describes all available fixedpoint solver parameters. *)
   val get_help : fixedpoint -> string
 
@@ -3124,28 +3124,28 @@ sig
   (** Retrieves parameter descriptions for Fixedpoint solver. *)
   val get_param_descrs : fixedpoint -> Params.ParamDescrs.param_descrs
 
-  (** Assert a constraints into the fixedpoint solver. *)        
+  (** Assert a constraints into the fixedpoint solver. *)
   val add : fixedpoint -> Expr.expr list -> unit
 
-  (** Register predicate as recursive relation. *)       
+  (** Register predicate as recursive relation. *)
   val register_relation : fixedpoint -> FuncDecl.func_decl -> unit
 
-  (** Add rule into the fixedpoint solver. *)        
+  (** Add rule into the fixedpoint solver. *)
   val add_rule : fixedpoint -> Expr.expr -> Symbol.symbol option -> unit
 
-  (** Add table fact to the fixedpoint solver. *)        
+  (** Add table fact to the fixedpoint solver. *)
   val add_fact : fixedpoint -> FuncDecl.func_decl -> int list -> unit
 
   (** Query the fixedpoint solver.
       A query is a conjunction of constraints. The constraints may include the recursively defined relations.
       The query is satisfiable if there is an instance of the query variables and a derivation for it.
-      The query is unsatisfiable if there are no derivations satisfying the query variables.  *)        
+      The query is unsatisfiable if there are no derivations satisfying the query variables.  *)
   val query : fixedpoint -> Expr.expr -> Solver.status
 
   (** Query the fixedpoint solver.
       A query is an array of relations.
       The query is satisfiable if there is an instance of some relation that is non-empty.
-      The query is unsatisfiable if there are no derivations satisfying any of the relations. *)        
+      The query is unsatisfiable if there are no derivations satisfying any of the relations. *)
   val query_r : fixedpoint -> FuncDecl.func_decl list -> Solver.status
 
   (** Creates a backtracking point.
@@ -3158,39 +3158,39 @@ sig
       {!push} *)
   val pop : fixedpoint -> unit
 
-  (** Update named rule into in the fixedpoint solver. *)        
+  (** Update named rule into in the fixedpoint solver. *)
   val update_rule : fixedpoint -> Expr.expr -> Symbol.symbol -> unit
 
-  (** Retrieve satisfying instance or instances of solver, 
-      or definitions for the recursive predicates that show unsatisfiability. *)                
+  (** Retrieve satisfying instance or instances of solver,
+      or definitions for the recursive predicates that show unsatisfiability. *)
   val get_answer : fixedpoint -> Expr.expr option
 
-  (** Retrieve explanation why fixedpoint engine returned status Unknown. *)                
+  (** Retrieve explanation why fixedpoint engine returned status Unknown. *)
   val get_reason_unknown : fixedpoint -> string
 
-  (** Retrieve the number of levels explored for a given predicate. *)                
+  (** Retrieve the number of levels explored for a given predicate. *)
   val get_num_levels : fixedpoint -> FuncDecl.func_decl -> int
 
-  (** Retrieve the cover of a predicate. *)                
+  (** Retrieve the cover of a predicate. *)
   val get_cover_delta : fixedpoint -> int -> FuncDecl.func_decl -> Expr.expr option
 
   (** Add <tt>property</tt> about the <tt>predicate</tt>.
-      The property is added at <tt>level</tt>. *)                
+      The property is added at <tt>level</tt>. *)
   val add_cover : fixedpoint -> int -> FuncDecl.func_decl -> Expr.expr -> unit
 
   (** Retrieve internal string representation of fixedpoint object. *)
   val to_string : fixedpoint -> string
 
-  (** Instrument the Datalog engine on which table representation to use for recursive predicate. *)                
+  (** Instrument the Datalog engine on which table representation to use for recursive predicate. *)
   val set_predicate_representation : fixedpoint -> FuncDecl.func_decl -> Symbol.symbol list -> unit
 
-  (** Convert benchmark given as set of axioms, rules and queries to a string. *)                
+  (** Convert benchmark given as set of axioms, rules and queries to a string. *)
   val to_string_q : fixedpoint -> Expr.expr list -> string
 
-  (** Retrieve set of rules added to fixedpoint context. *)                
+  (** Retrieve set of rules added to fixedpoint context. *)
   val get_rules : fixedpoint -> Expr.expr list
 
-  (** Retrieve set of assertions added to fixedpoint context. *)                
+  (** Retrieve set of assertions added to fixedpoint context. *)
   val get_assertions : fixedpoint -> Expr.expr list
 
   (** Create a Fixedpoint context. *)
@@ -3199,83 +3199,83 @@ sig
   (** Retrieve statistics information from the last call to #Z3_fixedpoint_query. *)
   val get_statistics : fixedpoint -> Statistics.statistics
 
-  (** Parse an SMT-LIB2 string with fixedpoint rules. 
-      Add the rules to the current fixedpoint context. 
+  (** Parse an SMT-LIB2 string with fixedpoint rules.
+      Add the rules to the current fixedpoint context.
       Return the set of queries in the string. *)
   val parse_string : fixedpoint -> string -> Expr.expr list
 
-  (** Parse an SMT-LIB2 file with fixedpoint rules. 
-      Add the rules to the current fixedpoint context. 
+  (** Parse an SMT-LIB2 file with fixedpoint rules.
+      Add the rules to the current fixedpoint context.
       Return the set of queries in the file. *)
   val parse_file : fixedpoint -> string -> Expr.expr list
 end
 
-(** Optimization *) 
-module Optimize : 
-sig 
-  type optimize  
-  type handle  
- 
-  (** Create a Optimize context. *) 
-  val mk_opt : context -> optimize 
-      
-  (** A string that describes all available optimize solver parameters. *) 
-  val get_help : optimize -> string 
- 
-  (** Sets the optimize solver parameters. *) 
-  val set_parameters : optimize -> Params.params -> unit 
- 
-  (** Retrieves parameter descriptions for Optimize solver. *) 
-  val get_param_descrs : optimize -> Params.ParamDescrs.param_descrs 
- 
-  (** Assert a constraints into the optimize solver. *)         
-  val add : optimize -> Expr.expr list -> unit 
- 
-  (** Asssert a soft constraint.  
-     Supply integer weight and string that identifies a group 
-      of soft constraints.  
-   *) 
-  val add_soft : optimize -> Expr.expr -> string -> Symbol.symbol -> handle 
- 
-  (** Add maximization objective. 
-   *)  
-  val maximize : optimize -> Expr.expr -> handle 
- 
-  (** Add minimization objective. 
-   *)  
-  val minimize : optimize -> Expr.expr -> handle 
-    
-  (** Checks whether the assertions in the context are satisfiable and solves objectives. 
-   *)         
-  val check : optimize -> Solver.status 
- 
-  (** Retrieve model from satisfiable context *) 
-  val get_model : optimize -> Model.model option
- 
-  (** Retrieve lower bound in current model for handle *) 
-  val get_lower : handle -> int -> Expr.expr 
- 
-  (** Retrieve upper bound in current model for handle *) 
-  val get_upper : handle -> int -> Expr.expr 
- 
-  (** Creates a backtracking point. 
-      {!pop} *) 
-  val push : optimize -> unit 
+(** Optimization *)
+module Optimize :
+sig
+  type optimize
+  type handle
 
-  (** Backtrack one backtracking point. 
-      Note that an exception is thrown if Pop is called without a corresponding [Push] 
-      {!push} *) 
-  val pop : optimize -> unit 
- 
-  (** Retrieve explanation why optimize engine returned status Unknown. *)                 
-  val get_reason_unknown : optimize -> string 
- 
-  (** Retrieve SMT-LIB string representation of optimize object. *) 
-  val to_string : optimize -> string 
- 
-  (** Retrieve statistics information from the last call to check *) 
-  val get_statistics : optimize -> Statistics.statistics 
-end 
+  (** Create a Optimize context. *)
+  val mk_opt : context -> optimize
+
+  (** A string that describes all available optimize solver parameters. *)
+  val get_help : optimize -> string
+
+  (** Sets the optimize solver parameters. *)
+  val set_parameters : optimize -> Params.params -> unit
+
+  (** Retrieves parameter descriptions for Optimize solver. *)
+  val get_param_descrs : optimize -> Params.ParamDescrs.param_descrs
+
+  (** Assert a constraints into the optimize solver. *)
+  val add : optimize -> Expr.expr list -> unit
+
+  (** Asssert a soft constraint.
+     Supply integer weight and string that identifies a group
+      of soft constraints.
+   *)
+  val add_soft : optimize -> Expr.expr -> string -> Symbol.symbol -> handle
+
+  (** Add maximization objective.
+   *)
+  val maximize : optimize -> Expr.expr -> handle
+
+  (** Add minimization objective.
+   *)
+  val minimize : optimize -> Expr.expr -> handle
+
+  (** Checks whether the assertions in the context are satisfiable and solves objectives.
+   *)
+  val check : optimize -> Solver.status
+
+  (** Retrieve model from satisfiable context *)
+  val get_model : optimize -> Model.model option
+
+  (** Retrieve lower bound in current model for handle *)
+  val get_lower : handle -> int -> Expr.expr
+
+  (** Retrieve upper bound in current model for handle *)
+  val get_upper : handle -> int -> Expr.expr
+
+  (** Creates a backtracking point.
+      {!pop} *)
+  val push : optimize -> unit
+
+  (** Backtrack one backtracking point.
+      Note that an exception is thrown if Pop is called without a corresponding [Push]
+      {!push} *)
+  val pop : optimize -> unit
+
+  (** Retrieve explanation why optimize engine returned status Unknown. *)
+  val get_reason_unknown : optimize -> string
+
+  (** Retrieve SMT-LIB string representation of optimize object. *)
+  val to_string : optimize -> string
+
+  (** Retrieve statistics information from the last call to check *)
+  val get_statistics : optimize -> Statistics.statistics
+end
 
 
 (** Functions for handling SMT and SMT2 expressions and files *)
@@ -3286,16 +3286,16 @@ sig
       @return A string representation of the benchmark. *)
   val benchmark_to_smtstring : context -> string -> string -> string -> string -> Expr.expr list -> Expr.expr -> string
 
-  (** Parse the given string using the SMT-LIB parser. 
-      
-      The symbol table of the parser can be initialized using the given sorts and declarations. 
-      The symbols in the arrays in the third and fifth argument 
-      don't need to match the names of the sorts and declarations in the arrays in the fourth 
-      and sixth argument. This is a useful feature since we can use arbitrary names to 
+  (** Parse the given string using the SMT-LIB parser.
+
+      The symbol table of the parser can be initialized using the given sorts and declarations.
+      The symbols in the arrays in the third and fifth argument
+      don't need to match the names of the sorts and declarations in the arrays in the fourth
+      and sixth argument. This is a useful feature since we can use arbitrary names to
       reference sorts and declarations. *)
   val parse_smtlib_string : context -> string -> Symbol.symbol list -> Sort.sort list -> Symbol.symbol list -> FuncDecl.func_decl list -> unit
 
-  (** Parse the given file using the SMT-LIB parser. 
+  (** Parse the given file using the SMT-LIB parser.
       {!parse_smtlib_string} *)
   val parse_smtlib_file : context -> string -> Symbol.symbol list -> Sort.sort list -> Symbol.symbol list -> FuncDecl.func_decl list -> unit
 
@@ -3323,13 +3323,13 @@ sig
   (** The sort declarations parsed by the last call to [ParseSMTLIBString] or [ParseSMTLIBFile]. *)
   val get_smtlib_sorts : context -> Sort.sort list
 
-  (** Parse the given string using the SMT-LIB2 parser. 
+  (** Parse the given string using the SMT-LIB2 parser.
 
       {!parse_smtlib_string}
       @return A conjunction of assertions in the scope (up to push/pop) at the end of the string. *)
   val parse_smtlib2_string : context -> string -> Symbol.symbol list -> Sort.sort list -> Symbol.symbol list -> FuncDecl.func_decl list -> Expr.expr
 
-  (** Parse the given file using the SMT-LIB2 parser. 
+  (** Parse the given file using the SMT-LIB2 parser.
       {!parse_smtlib2_string} *)
   val parse_smtlib2_file : context -> string -> Symbol.symbol list -> Sort.sort list -> Symbol.symbol list -> FuncDecl.func_decl list -> Expr.expr
 end
@@ -3341,7 +3341,7 @@ sig
   (** Create an AST node marking a formula position for interpolation.
       The expression must have Boolean sort. *)
   val mk_interpolant : context -> Expr.expr -> Expr.expr
-    
+
   (** The interpolation context is suitable for generation of interpolants.
       For more information on interpolation please refer
       too the C/C++ API, which is well documented. *)
@@ -3361,12 +3361,12 @@ sig
       For more information on interpolation please refer
       too the C/C++ API, which is well documented. *)
   val get_interpolation_profile : context -> string
-    
+
   (** Read an interpolation problem from file.
       For more information on interpolation please refer
       too the C/C++ API, which is well documented. *)
   val read_interpolation_problem : context -> string -> (Expr.expr list * int list * Expr.expr list)
-    
+
   (** Check the correctness of an interpolant.
       For more information on interpolation please refer
       too the C/C++ API, which is well documented. *)
@@ -3381,10 +3381,10 @@ sig
 end
 
 (** Set a global (or module) parameter, which is shared by all Z3 contexts.
-    
+
     When a Z3 module is initialized it will use the value of these parameters
     when Z3_params objects are not provided.
-    The name of parameter can be composed of characters [a-z][A-Z], digits [0-9], '-' and '_'. 
+    The name of parameter can be composed of characters [a-z][A-Z], digits [0-9], '-' and '_'.
     The character '.' is a delimiter (more later).
     The parameter names are case-insensitive. The character '-' should be viewed as an "alias" for '_'.
     Thus, the following parameter names are considered equivalent: "pp.decimal-precision"  and "PP.DECIMAL_PRECISION".
@@ -3397,7 +3397,7 @@ end
 val set_global_param : string -> string -> unit
 
 (** Get a global (or module) parameter.
-    
+
     Returns None if the parameter does not exist.
     The caller must invoke #Z3_global_param_del_value to delete the value returned at param_value.
     This function cannot be invoked simultaneously from different threads without synchronization.
@@ -3406,32 +3406,29 @@ val set_global_param : string -> string -> unit
 val get_global_param : string -> string option
 
 (** Restore the value of all global (and module) parameters.
-    
+
     This command will not affect already created objects (such as tactics and solvers)
     {!set_global_param}
 *)
 
 val global_param_reset_all : unit -> unit
-  
+
 (** Enable/disable printing of warning messages to the console.
-    
-    Note that this function is static and effects the behaviour of 
+
+    Note that this function is static and effects the behaviour of
     all contexts globally. *)
 val toggle_warning_messages : bool -> unit
 
 (**
    Enable tracing messages tagged as `tag' when Z3 is compiled in debug mode.
-   
-   Remarks: It is a NOOP otherwise. 
+
+   Remarks: It is a NOOP otherwise.
 *)
 val enable_trace : string -> unit
 
 (**
-   Disable tracing messages tagged as `tag' when Z3 is compiled in debug mode.        
+   Disable tracing messages tagged as `tag' when Z3 is compiled in debug mode.
 
    Remarks: It is a NOOP otherwise.
 *)
 val disable_trace : string -> unit
-
-
-

--- a/src/api/ml/z3.mli
+++ b/src/api/ml/z3.mli
@@ -285,7 +285,7 @@ sig
   sig
     (** Parameters of func_decls *)
     type parameter =
-                P_Int of int
+        P_Int of int
       | P_Dbl of float
       | P_Sym of Symbol.symbol
       | P_Srt of Sort.sort
@@ -3232,21 +3232,21 @@ sig
   val add : optimize -> Expr.expr list -> unit
 
   (** Asssert a soft constraint.
-     Supply integer weight and string that identifies a group
+      Supply integer weight and string that identifies a group
       of soft constraints.
-   *)
+  *)
   val add_soft : optimize -> Expr.expr -> string -> Symbol.symbol -> handle
 
   (** Add maximization objective.
-   *)
+  *)
   val maximize : optimize -> Expr.expr -> handle
 
   (** Add minimization objective.
-   *)
+  *)
   val minimize : optimize -> Expr.expr -> handle
 
   (** Checks whether the assertions in the context are satisfiable and solves objectives.
-   *)
+  *)
   val check : optimize -> Solver.status
 
   (** Retrieve model from satisfiable context *)

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -159,6 +159,10 @@ void Z3_context_finalize(value v) {
 }
 
 int Z3_context_compare(value v1, value v2) {
+  /* As each context created within the OCaml bindings has a unique
+     Z3_context_plus_data allocated to store the handle and the ref counters,
+     we can just compare pointers here. This suffices to test for (in)equality
+     and induces an arbitrary (but fixed) ordering. */
   Z3_context_plus cp1 = *(Z3_context_plus*)Data_custom_val(v1);
   Z3_context_plus cp2 = *(Z3_context_plus*)Data_custom_val(v2);
   return compare_pointers(cp1, cp2);
@@ -172,6 +176,8 @@ int Z3_context_compare_ext(value v1, value v2) {
 /* We use the pointer to the Z3_context_plus_data structure as
    a hash value; it is unique, at least. */
 intnat Z3_context_hash(value v) {
+  /* We use the address of the context's Z3_context_plus_data structure
+     as a hash value */
   Z3_context_plus cp = *(Z3_context_plus*)Data_custom_val(v);
   return (intnat)cp;
 }

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -63,6 +63,14 @@ static struct custom_operations default_custom_ops = {
   custom_compare_ext_default,
 };
 
+inline int compare_pointers(void* pt1, void* pt2) {
+  if (pt1 == pt2)
+    return 0;
+  else if ((intnat)pt1 < (intnat)pt2)
+    return -1;
+  else
+    return +1;
+}
 
 #define MK_CTX_OF(X)                                                    \
   CAMLprim DLL_PUBLIC value n_context_of_ ## X(value v) {               \
@@ -150,14 +158,32 @@ void Z3_context_finalize(value v) {
   try_to_delete_context(cp);
 }
 
+int Z3_context_compare(value v1, value v2) {
+  Z3_context_plus cp1 = *(Z3_context_plus*)Data_custom_val(v1);
+  Z3_context_plus cp2 = *(Z3_context_plus*)Data_custom_val(v2);
+  return compare_pointers(cp1, cp2);
+}
+
+int Z3_context_compare_ext(value v1, value v2) {
+  Z3_context_plus cp = *(Z3_context_plus*)Data_custom_val(v1);
+  return compare_pointers(cp, (void*)Val_int(v2));
+}
+
+/* We use the pointer to the Z3_context_plus_data structure as
+   a hash value; it is unique, at least. */
+intnat Z3_context_hash(value v) {
+  Z3_context_plus cp = *(Z3_context_plus*)Data_custom_val(v);
+  return (intnat)cp;
+}
+
 static struct custom_operations Z3_context_plus_custom_ops = {
   (char*) "Z3_context ops",
   Z3_context_finalize,
-  custom_compare_default,
-  custom_hash_default,
+  Z3_context_compare,
+  Z3_context_hash,
   custom_serialize_default,
   custom_deserialize_default,
-  custom_compare_ext_default,
+  Z3_context_compare_ext
 };
 
 
@@ -195,13 +221,21 @@ void Z3_ast_finalize(value v) {
 int Z3_ast_compare(value v1, value v2) {
   Z3_ast_plus * a1 = (Z3_ast_plus*)Data_custom_val(v1);
   Z3_ast_plus * a2 = (Z3_ast_plus*)Data_custom_val(v2);
-  assert(a1->cp->ctx == a2->cp->ctx);
+
+  /* if the two ASTs belong to different contexts, we take
+     their contexts' addresses to order them (arbitrarily, but fixed) */
+  if (a1->cp->ctx != a2->cp->ctx)
+     return compare_pointers(a1->cp->ctx, a2->cp->ctx);
+
+  /* handling of NULL pointers */
   if (a1->p == NULL && a2->p == NULL)
     return 0;
   if (a1->p == NULL)
     return -1;
   if (a2->p == NULL)
     return +1;
+
+  /* Comparison according to AST ids. */
   unsigned id1 = Z3_get_ast_id(a1->cp->ctx, a1->p);
   unsigned id2 = Z3_get_ast_id(a2->cp->ctx, a2->p);
   if (id1 == id2)
@@ -275,14 +309,33 @@ MK_CTX_OF(ast)
     try_to_delete_context(pp->cp);                                      \
   }                                                                     \
   									\
+  int Z3_ ## X ## _compare(value v1, value v2) {                        \
+    Z3_ ## X ## _plus * pp1 = (Z3_ ## X ## _plus*)Data_custom_val(v1);  \
+    Z3_ ## X ## _plus * pp2 = (Z3_ ## X ## _plus*)Data_custom_val(v2);  \
+    if (pp1->cp != pp2->cp)						\
+      return compare_pointers(pp1->cp, pp2->cp);			\
+    else     			       					\
+      return compare_pointers(pp1->p, pp2->p);				\
+  }                                                                     \
+  									\
+  intnat Z3_ ## X ## _hash(value v) {					\
+    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v);    \
+    return (intnat)pp->p;						\
+  }                                                                     \
+  									\
+  int Z3_ ## X ## _compare_ext(value v1, value v2) {                    \
+    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v1);  	\
+    return compare_pointers(pp->p, (void*)Val_int(v2));			\
+  }                                                                     \
+  									\
   static struct custom_operations Z3_ ## X ## _plus_custom_ops = {      \
     (char*) "Z3_" #X " ops",                                            \
     Z3_ ## X ## _finalize,                                              \
-    custom_compare_default,                                             \
-    custom_hash_default,                                                \
+    Z3_ ## X ## _compare,                                              	\
+    Z3_ ## X ## _hash,                                                 	\
     custom_serialize_default,                                           \
     custom_deserialize_default,                                         \
-    custom_compare_ext_default,                                         \
+    Z3_ ## X ## _compare_ext						\
   };                                                                    \
                                                                         \
   MK_CTX_OF(X)
@@ -315,14 +368,33 @@ MK_CTX_OF(ast)
     try_to_delete_context(pp->cp);                                      \
   }                                                                     \
                                                                         \
+  int Z3_ ## X ## _compare(value v1, value v2) {                        \
+    Z3_ ## X ## _plus * pp1 = (Z3_ ## X ## _plus*)Data_custom_val(v1);  \
+    Z3_ ## X ## _plus * pp2 = (Z3_ ## X ## _plus*)Data_custom_val(v2);  \
+    if (pp1->cp != pp2->cp)						\
+      return compare_pointers(pp1->cp, pp2->cp);			\
+    else     			       					\
+      return compare_pointers(pp1->p, pp2->p);				\
+  }                                                                     \
+  									\
+  intnat Z3_ ## X ## _hash(value v) {					\
+    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v);    \
+    return (intnat)pp->p;						\
+  }                                                                     \
+  									\
+  int Z3_ ## X ## _compare_ext(value v1, value v2) {                    \
+    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v1);  	\
+    return compare_pointers(pp->p, (void*)Val_int(v2));		       	\
+  }                                                                     \
+  									\
   static struct custom_operations Z3_ ## X ## _plus_custom_ops = {      \
     (char*) "Z3_" #X " ops",                                            \
     Z3_ ## X ## _finalize,                                              \
-    custom_compare_default,                                             \
-    custom_hash_default,                                                \
+    Z3_ ## X ## _compare,                                              	\
+    Z3_ ## X ## _hash,                                                 	\
     custom_serialize_default,                                           \
     custom_deserialize_default,                                         \
-    custom_compare_ext_default,                                         \
+    Z3_ ## X ## _compare_ext						\
   };                                                                    \
                                                                         \
   MK_CTX_OF(X)

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -24,32 +24,32 @@ extern "C" {
 #include <z3.h>
 #include <z3native_stubs.h>
 
-#define CAMLlocal6(X1,X2,X3,X4,X5,X6)                               \
-  CAMLlocal5(X1,X2,X3,X4,X5);                                       \
+#define CAMLlocal6(X1,X2,X3,X4,X5,X6)                                   \
+  CAMLlocal5(X1,X2,X3,X4,X5);                                       	\
   CAMLlocal1(X6)
-#define CAMLlocal7(X1,X2,X3,X4,X5,X6,X7)                            \
-  CAMLlocal5(X1,X2,X3,X4,X5);                                       \
+#define CAMLlocal7(X1,X2,X3,X4,X5,X6,X7)				\
+  CAMLlocal5(X1,X2,X3,X4,X5);                                       	\
   CAMLlocal2(X6,X7)
-#define CAMLlocal8(X1,X2,X3,X4,X5,X6,X7,X8)                         \
-  CAMLlocal5(X1,X2,X3,X4,X5);                                       \
+#define CAMLlocal8(X1,X2,X3,X4,X5,X6,X7,X8)				\
+  CAMLlocal5(X1,X2,X3,X4,X5);                                       	\
   CAMLlocal3(X6,X7,X8)
 
-#define CAMLparam7(X1,X2,X3,X4,X5,X6,X7)                            \
-  CAMLparam5(X1,X2,X3,X4,X5);                                       \
+#define CAMLparam7(X1,X2,X3,X4,X5,X6,X7)				\
+  CAMLparam5(X1,X2,X3,X4,X5);                                       	\
   CAMLxparam2(X6,X7)
-#define CAMLparam8(X1,X2,X3,X4,X5,X6,X7,X8)                         \
-  CAMLparam5(X1,X2,X3,X4,X5);                                       \
+#define CAMLparam8(X1,X2,X3,X4,X5,X6,X7,X8)				\
+  CAMLparam5(X1,X2,X3,X4,X5);                                       	\
   CAMLxparam3(X6,X7,X8)
-#define CAMLparam9(X1,X2,X3,X4,X5,X6,X7,X8,X9)                      \
-  CAMLparam5(X1,X2,X3,X4,X5);                                       \
+#define CAMLparam9(X1,X2,X3,X4,X5,X6,X7,X8,X9)				\
+  CAMLparam5(X1,X2,X3,X4,X5);                                       	\
   CAMLxparam4(X6,X7,X8,X9)
-#define CAMLparam12(X1,X2,X3,X4,X5,X6,X7,X8,X9,X10,X11,X12)     \
-  CAMLparam5(X1,X2,X3,X4,X5);                                   \
-  CAMLxparam5(X6,X7,X8,X9,X10);                                 \
+#define CAMLparam12(X1,X2,X3,X4,X5,X6,X7,X8,X9,X10,X11,X12)		\
+  CAMLparam5(X1,X2,X3,X4,X5);                                   	\
+  CAMLxparam5(X6,X7,X8,X9,X10);                                 	\
   CAMLxparam2(X11,X12)
-#define CAMLparam13(X1,X2,X3,X4,X5,X6,X7,X8,X9,X10,X11,X12,X13) \
-  CAMLparam5(X1,X2,X3,X4,X5);                                   \
-  CAMLxparam5(X6,X7,X8,X9,X10);                                 \
+#define CAMLparam13(X1,X2,X3,X4,X5,X6,X7,X8,X9,X10,X11,X12,X13)		\
+  CAMLparam5(X1,X2,X3,X4,X5);                                   	\
+  CAMLxparam5(X6,X7,X8,X9,X10);                                 	\
   CAMLxparam3(X11,X12,X13)
 
 
@@ -76,31 +76,31 @@ inline int compare_pointers(void* pt1, void* pt2) {
   CAMLprim DLL_PUBLIC value n_context_of_ ## X(value v) {               \
     CAMLparam1(v);                                                      \
     CAMLlocal1(result);                                                 \
-    Z3_context_plus cp;							\
+    Z3_context_plus cp;                                                 \
     Z3_ ## X ## _plus * p = (Z3_ ## X ## _plus *) Data_custom_val(v);   \
-    cp = p->cp;								\
+    cp = p->cp;                                                         \
     result = caml_alloc_custom(&Z3_context_plus_custom_ops, sizeof(Z3_context_plus), 0, 1); \
-    *(Z3_context_plus *)Data_custom_val(result) = cp; 	                \
+    *(Z3_context_plus *)Data_custom_val(result) = cp;                   \
     /* We increment the usage counter of the context, as we just        \
        created a second custom block holding that context        */     \
-    cp->obj_count++;							\
+    cp->obj_count++;                                                    \
     CAMLreturn(result);                                                 \
-  } 									\
-  									\
-  CAMLprim value DLL_PUBLIC n_is_null_ ## X (value v) {			\
-    CAMLparam1(v);	    	     		       	  		\
-    Z3_ ## X ## _plus* pp = (Z3_ ## X ## _plus*)Data_custom_val(v);	\
-    CAMLreturn(Val_bool(pp->p == NULL)); 				\
-  } 			      	 					\
-									\
-  CAMLprim value DLL_PUBLIC n_mk_null_ ## X (value v) {			\
-    CAMLparam1(v);	    	     		       	  		\
-    CAMLlocal1(result);							\
-    Z3_context_plus cp = *(Z3_context_plus*)(Data_custom_val(v));	\
-    Z3_ ## X ## _plus a = Z3_ ## X ## _plus_mk(cp, NULL);		\
+  }                                                                     \
+                                                                        \
+  CAMLprim value DLL_PUBLIC n_is_null_ ## X (value v) {                 \
+    CAMLparam1(v);                                                      \
+    Z3_ ## X ## _plus* pp = (Z3_ ## X ## _plus*)Data_custom_val(v);     \
+    CAMLreturn(Val_bool(pp->p == NULL));                                \
+  }                                                                     \
+                                                                        \
+  CAMLprim value DLL_PUBLIC n_mk_null_ ## X (value v) {                 \
+    CAMLparam1(v);                                                      \
+    CAMLlocal1(result);                                                 \
+    Z3_context_plus cp = *(Z3_context_plus*)(Data_custom_val(v));       \
+    Z3_ ## X ## _plus a = Z3_ ## X ## _plus_mk(cp, NULL);               \
     result = caml_alloc_custom(&Z3_ ## X ## _plus_custom_ops, sizeof(Z3_ ## X ## _plus), 0, 1); \
-    *(Z3_ ## X ## _plus*)(Data_custom_val(result)) = a;	      		\
-    CAMLreturn(result);							\
+    *(Z3_ ## X ## _plus*)(Data_custom_val(result)) = a;                 \
+    CAMLreturn(result);                                                 \
   }
 
 
@@ -314,34 +314,34 @@ MK_CTX_OF(ast)
     pp->cp->obj_count--;                                                \
     try_to_delete_context(pp->cp);                                      \
   }                                                                     \
-  									\
+                                                                        \
   int Z3_ ## X ## _compare(value v1, value v2) {                        \
     Z3_ ## X ## _plus * pp1 = (Z3_ ## X ## _plus*)Data_custom_val(v1);  \
     Z3_ ## X ## _plus * pp2 = (Z3_ ## X ## _plus*)Data_custom_val(v2);  \
-    if (pp1->cp != pp2->cp)						\
-      return compare_pointers(pp1->cp, pp2->cp);			\
-    else     			       					\
-      return compare_pointers(pp1->p, pp2->p);				\
+    if (pp1->cp != pp2->cp)                                             \
+      return compare_pointers(pp1->cp, pp2->cp);                        \
+    else                                                                \
+      return compare_pointers(pp1->p, pp2->p);                          \
   }                                                                     \
-  									\
-  intnat Z3_ ## X ## _hash(value v) {					\
+                                                                        \
+  intnat Z3_ ## X ## _hash(value v) {                                   \
     Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v);    \
-    return (intnat)pp->p;						\
+    return (intnat)pp->p;                                               \
   }                                                                     \
-  									\
+                                                                        \
   int Z3_ ## X ## _compare_ext(value v1, value v2) {                    \
-    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v1);  	\
-    return compare_pointers(pp->p, (void*)Val_int(v2));			\
+    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v1);   \
+    return compare_pointers(pp->p, (void*)Val_int(v2));                 \
   }                                                                     \
-  									\
+                                                                        \
   static struct custom_operations Z3_ ## X ## _plus_custom_ops = {      \
     (char*) "Z3_" #X " ops",                                            \
     Z3_ ## X ## _finalize,                                              \
-    Z3_ ## X ## _compare,                                              	\
-    Z3_ ## X ## _hash,                                                 	\
+    Z3_ ## X ## _compare,                                               \
+    Z3_ ## X ## _hash,                                                  \
     custom_serialize_default,                                           \
     custom_deserialize_default,                                         \
-    Z3_ ## X ## _compare_ext						\
+    Z3_ ## X ## _compare_ext                                            \
   };                                                                    \
                                                                         \
   MK_CTX_OF(X)
@@ -357,7 +357,7 @@ MK_CTX_OF(ast)
       r.cp = cp;                                                        \
       r.p = p;                                                          \
       r.cp->obj_count++;                                                \
-      if (p != NULL)							\
+      if (p != NULL)                                                    \
         Z3_ ## X ## _inc_ref(cp->ctx, p);                               \
       return r;                                                         \
   }                                                                     \
@@ -368,7 +368,7 @@ MK_CTX_OF(ast)
                                                                         \
   void Z3_ ## X ## _finalize(value v) {                                 \
     Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v);    \
-    if (pp->p != NULL)							\
+    if (pp->p != NULL)                                                  \
       Z3_ ## X ## _dec_ref(pp->cp->ctx, pp->p);                         \
     pp->cp->obj_count--;                                                \
     try_to_delete_context(pp->cp);                                      \
@@ -377,30 +377,30 @@ MK_CTX_OF(ast)
   int Z3_ ## X ## _compare(value v1, value v2) {                        \
     Z3_ ## X ## _plus * pp1 = (Z3_ ## X ## _plus*)Data_custom_val(v1);  \
     Z3_ ## X ## _plus * pp2 = (Z3_ ## X ## _plus*)Data_custom_val(v2);  \
-    if (pp1->cp != pp2->cp)						\
-      return compare_pointers(pp1->cp, pp2->cp);			\
-    else     			       					\
-      return compare_pointers(pp1->p, pp2->p);				\
+    if (pp1->cp != pp2->cp)                                             \
+      return compare_pointers(pp1->cp, pp2->cp);                        \
+    else                                                                \
+      return compare_pointers(pp1->p, pp2->p);                          \
   }                                                                     \
-  									\
-  intnat Z3_ ## X ## _hash(value v) {					\
+                                                                        \
+  intnat Z3_ ## X ## _hash(value v) {                                   \
     Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v);    \
-    return (intnat)pp->p;						\
+    return (intnat)pp->p;                                               \
   }                                                                     \
-  									\
+                                                                        \
   int Z3_ ## X ## _compare_ext(value v1, value v2) {                    \
-    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v1);  	\
-    return compare_pointers(pp->p, (void*)Val_int(v2));		       	\
+    Z3_ ## X ## _plus * pp = (Z3_ ## X ## _plus*)Data_custom_val(v1);   \
+    return compare_pointers(pp->p, (void*)Val_int(v2));                 \
   }                                                                     \
-  									\
+                                                                        \
   static struct custom_operations Z3_ ## X ## _plus_custom_ops = {      \
     (char*) "Z3_" #X " ops",                                            \
     Z3_ ## X ## _finalize,                                              \
-    Z3_ ## X ## _compare,                                              	\
-    Z3_ ## X ## _hash,                                                 	\
+    Z3_ ## X ## _compare,                                               \
+    Z3_ ## X ## _hash,                                                  \
     custom_serialize_default,                                           \
     custom_deserialize_default,                                         \
-    Z3_ ## X ## _compare_ext						\
+    Z3_ ## X ## _compare_ext                                            \
   };                                                                    \
                                                                         \
   MK_CTX_OF(X)
@@ -424,7 +424,6 @@ MK_PLUS_OBJ(ast_map)
 MK_PLUS_OBJ(ast_vector)
 MK_PLUS_OBJ(fixedpoint)
 MK_PLUS_OBJ(optimize)
-
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This patch brings some simplifications to Z3's OCaml bindings. It does not modify the public API.

Changes include
- Use the standard structural equality (and inequality) operators `=` (`<>`) instead of physical equality `==` (`!=`) throughout z3.ml
- Implement comparison operators within the C layer as a custom_block operation.
- Remove superfluous ML2C wrapper in auto-generated z3native.ml
- Remove the apply{1,2,3,4} and their use functions that were introduced to fix a bug in the old OCaml API
- Try to handle list arguments more efficiently (traverse lists only once)
- Curry arguments that can be passed to the C layer, directly.
