### PR TITLE
Make the C-layer of Z3's OCaml bindings compatible with C89 (for older Visual Studio builds)

### DIFF
--- a/scripts/mk_unix_dist.py
+++ b/scripts/mk_unix_dist.py
@@ -58,7 +58,7 @@ def display_help():
 
 # Parse configuration option for mk_make script
 def parse_options():
-    global FORCE_MK, JAVA_ENABLED, GIT_HASH
+    global FORCE_MK, JAVA_ENABLED, GIT_HASH, DOTNET_ENABLED
     path = BUILD_DIR
     options, remainder = getopt.gnu_getopt(sys.argv[1:], 'b:hsf', ['build=', 
                                                                    'help',

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -63,7 +63,7 @@ def display_help():
 
 # Parse configuration option for mk_make script
 def parse_options():
-    global FORCE_MK, JAVA_ENABLED, GIT_HASH
+    global FORCE_MK, JAVA_ENABLED, GIT_HASH, DOTNET_ENABLED
     path = BUILD_DIR
     options, remainder = getopt.gnu_getopt(sys.argv[1:], 'b:hsf', ['build=', 
                                                                    'help',

--- a/src/ackermannization/ackermannize_bv_tactic.cpp
+++ b/src/ackermannization/ackermannize_bv_tactic.cpp
@@ -74,6 +74,10 @@ public:
         m_lemma_limit = p.div0_ackermann_limit();
     }
 
+    virtual void collect_param_descrs(param_descrs & r) {
+        ackermannize_bv_tactic_params::collect_param_descrs(r);
+    }
+
     virtual void collect_statistics(statistics & st) const {
         st.update("ackr-constraints", m_st.m_ackrs_sz);
     }

--- a/src/ackermannization/lackr.cpp
+++ b/src/ackermannization/lackr.cpp
@@ -134,7 +134,6 @@ void lackr::eager_enc() {
     const fun2terms_map::iterator e = m_fun2terms.end();
     for (fun2terms_map::iterator i = m_fun2terms.begin(); i != e; ++i) {
         checkpoint();
-        func_decl* const fd = i->m_key;
         app_set * const  ts = i->get_value();
         const app_set::iterator r = ts->end();
         for (app_set::iterator j = ts->begin(); j != r; ++j) {
@@ -143,8 +142,8 @@ void lackr::eager_enc() {
             for (;  k != r; ++k) {
                 app * const t1 = *j;
                 app * const t2 = *k;
-                SASSERT(t1->get_decl() == fd);
-                SASSERT(t2->get_decl() == fd);
+                SASSERT(t1->get_decl() == i->m_key);
+                SASSERT(t2->get_decl() == i->m_key);
                 if (t1 == t2) continue;
                 ackr(t1,t2);
             }

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -1066,15 +1066,14 @@ extern "C" {
             case OP_BV2INT:    return Z3_OP_BV2INT;
             case OP_CARRY:     return Z3_OP_CARRY;
             case OP_XOR3:      return Z3_OP_XOR3;
-            case OP_BSMUL_NO_OVFL:
-            case OP_BUMUL_NO_OVFL:
-            case OP_BSMUL_NO_UDFL:
-            case OP_BSDIV_I:
-            case OP_BUDIV_I:
-            case OP_BSREM_I:
-            case OP_BUREM_I:
-            case OP_BSMOD_I:
-                return Z3_OP_UNINTERPRETED;
+            case OP_BSMUL_NO_OVFL: return Z3_OP_BSMUL_NO_OVFL;
+            case OP_BUMUL_NO_OVFL: return Z3_OP_BUMUL_NO_OVFL;
+            case OP_BSMUL_NO_UDFL: return Z3_OP_BSMUL_NO_UDFL;
+            case OP_BSDIV_I: return Z3_OP_BSDIV_I;
+            case OP_BUDIV_I: return Z3_OP_BUDIV_I;
+            case OP_BSREM_I: return Z3_OP_BSREM_I;
+            case OP_BUREM_I: return Z3_OP_BUREM_I;
+            case OP_BSMOD_I: return Z3_OP_BSMOD_I;
             default:
                 UNREACHABLE();
                 return Z3_OP_UNINTERPRETED;

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -1185,7 +1185,7 @@ extern "C" {
             case OP_FPA_TO_IEEE_BV: return Z3_OP_FPA_TO_IEEE_BV;
             case OP_FPA_INTERNAL_MIN_I: return Z3_OP_FPA_MIN_I;
             case OP_FPA_INTERNAL_MAX_I: return Z3_OP_FPA_MAX_I;
-            case OP_FPA_INTERNAL_RM_BVWRAP:
+            case OP_FPA_INTERNAL_BV2RM:
             case OP_FPA_INTERNAL_BVWRAP:
             case OP_FPA_INTERNAL_MIN_UNSPECIFIED:
             case OP_FPA_INTERNAL_MAX_UNSPECIFIED:

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -1183,10 +1183,10 @@ extern "C" {
             case OP_FPA_TO_SBV: return Z3_OP_FPA_TO_SBV;
             case OP_FPA_TO_REAL: return Z3_OP_FPA_TO_REAL;
             case OP_FPA_TO_IEEE_BV: return Z3_OP_FPA_TO_IEEE_BV;
+            case OP_FPA_INTERNAL_MIN_I: return Z3_OP_FPA_MIN_I;
+            case OP_FPA_INTERNAL_MAX_I: return Z3_OP_FPA_MAX_I;
+            case OP_FPA_INTERNAL_RM_BVWRAP:
             case OP_FPA_INTERNAL_BVWRAP:
-            case OP_FPA_INTERNAL_BVUNWRAP:
-            case OP_FPA_INTERNAL_MIN_I:
-            case OP_FPA_INTERNAL_MAX_I:
             case OP_FPA_INTERNAL_MIN_UNSPECIFIED:
             case OP_FPA_INTERNAL_MAX_UNSPECIFIED:
             case OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED:

--- a/src/api/api_model.cpp
+++ b/src/api/api_model.cpp
@@ -50,14 +50,13 @@ extern "C" {
         Z3_CATCH;
     }
 
-    Z3_ast Z3_API Z3_model_get_const_interp(Z3_context c, Z3_model m, Z3_func_decl a) {
+    Z3_ast_opt Z3_API Z3_model_get_const_interp(Z3_context c, Z3_model m, Z3_func_decl a) {
         Z3_TRY;
         LOG_Z3_model_get_const_interp(c, m, a);
         RESET_ERROR_CODE();
         CHECK_NON_NULL(m, 0);
         expr * r = to_model_ref(m)->get_const_interp(to_func_decl(a));
         if (!r) {
-            SET_ERROR_CODE(Z3_INVALID_ARG);
             RETURN_Z3(0);
         }
         mk_c(c)->save_ast_trail(r);

--- a/src/api/api_quant.cpp
+++ b/src/api/api_quant.cpp
@@ -72,7 +72,7 @@ extern "C" {
         expr * const* no_ps = reinterpret_cast<expr * const*>(no_patterns);
         pattern_validator v(mk_c(c)->m());
         for (unsigned i = 0; i < num_patterns; i++) {
-            if (!v(num_decls, ps[i])) {
+            if (!v(num_decls, ps[i], 0, 0)) {
                 SET_ERROR_CODE(Z3_INVALID_PATTERN);
                 return 0;
             }

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -1582,6 +1582,9 @@ namespace z3 {
 	    return static_cast<unsigned>(i) < num_consts() ? get_const_decl(i) : get_func_decl(i - num_consts());
 	}
 
+        // returns interpretation of constant declaration c.
+        // If c is not assigned any value in the model it returns 
+        // an expression with a null ast reference.
         expr get_const_interp(func_decl c) const {
             check_context(*this, c);
             Z3_ast r = Z3_model_get_const_interp(ctx(), m_model, c);

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -227,6 +227,7 @@ void Z3_ast_finalize(value v) {
 int Z3_ast_compare(value v1, value v2) {
   Z3_ast_plus * a1 = (Z3_ast_plus*)Data_custom_val(v1);
   Z3_ast_plus * a2 = (Z3_ast_plus*)Data_custom_val(v2);
+  unsigned id1, id2;
 
   /* if the two ASTs belong to different contexts, we take
      their contexts' addresses to order them (arbitrarily, but fixed) */
@@ -242,8 +243,8 @@ int Z3_ast_compare(value v1, value v2) {
     return +1;
 
   /* Comparison according to AST ids. */
-  unsigned id1 = Z3_get_ast_id(a1->cp->ctx, a1->p);
-  unsigned id2 = Z3_get_ast_id(a2->cp->ctx, a2->p);
+  id1 = Z3_get_ast_id(a1->cp->ctx, a1->p);
+  id2 = Z3_get_ast_id(a2->cp->ctx, a2->p);
   if (id1 == id2)
     return 0;
   else if (id1 < id2)
@@ -255,7 +256,7 @@ int Z3_ast_compare(value v1, value v2) {
 int Z3_ast_compare_ext(value v1, value v2) {
   Z3_ast_plus * a1 = (Z3_ast_plus*)Data_custom_val(v1);
   unsigned id1;
-  int id2 = Val_int(v2);
+  unsigned id2 = (unsigned)Val_int(v2);
   if (a1->p == NULL && id2 == 0)
     return 0;
   if (a1->p == NULL)

--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -5516,7 +5516,10 @@ class ModelRef(Z3PPObject):
             decl = decl.decl()
         try:
             if decl.arity() == 0:
-                r = _to_expr_ref(Z3_model_get_const_interp(self.ctx.ref(), self.model, decl.ast), self.ctx)
+                _r = Z3_model_get_const_interp(self.ctx.ref(), self.model, decl.ast)
+                if _r.value is None:
+                    return None
+                r = _to_expr_ref(_r, self.ctx)
                 if is_as_array(r):
                     return self.get_interp(get_as_array_func(r))
                 else:

--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -3468,7 +3468,7 @@ def is_bv_value(a):
     """
     return is_bv(a) and _is_numeral(a.ctx, a.as_ast())
 
-def BV2Int(a):
+def BV2Int(a, is_signed=False):
     """Return the Z3 expression BV2Int(a).
 
     >>> b = BitVec('b', 3)
@@ -3477,6 +3477,10 @@ def BV2Int(a):
     >>> x = Int('x')
     >>> x > BV2Int(b)
     x > BV2Int(b)
+    >>> x > BV2Int(b, is_signed=False)
+    x > BV2Int(b)
+    >>> x > BV2Int(b, is_signed=True)
+    x > If(b < 0, BV2Int(b) - 8, BV2Int(b))
     >>> solve(x > BV2Int(b), b == 1, x < 3)
     [b = 1, x = 2]
     """
@@ -3484,7 +3488,7 @@ def BV2Int(a):
         _z3_assert(is_bv(a), "Z3 bit-vector expression expected")
     ctx = a.ctx
     ## investigate problem with bv2int
-    return ArithRef(Z3_mk_bv2int(ctx.ref(), a.as_ast(), 0), ctx)
+    return ArithRef(Z3_mk_bv2int(ctx.ref(), a.as_ast(), is_signed), ctx)
 
 def BitVecSort(sz, ctx=None):
     """Return a Z3 bit-vector sort of the given size. If `ctx=None`, then the global context is used.

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1060,6 +1060,15 @@ typedef enum {
     Z3_OP_CARRY,
     Z3_OP_XOR3,
 
+    Z3_OP_BSMUL_NO_OVFL,
+    Z3_OP_BUMUL_NO_OVFL,
+    Z3_OP_BSMUL_NO_UDFL,
+    Z3_OP_BSDIV_I,
+    Z3_OP_BUDIV_I,
+    Z3_OP_BSREM_I,
+    Z3_OP_BUREM_I,
+    Z3_OP_BSMOD_I,
+
     // Proofs
     Z3_OP_PR_UNDEF = 0x500,
     Z3_OP_PR_TRUE,

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1214,6 +1214,9 @@ typedef enum {
 
     Z3_OP_FPA_TO_IEEE_BV,
 
+    Z3_OP_FPA_MIN_I,
+    Z3_OP_FPA_MAX_I,
+
     Z3_OP_UNINTERPRETED
 } Z3_decl_kind;
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1495,6 +1495,7 @@ void ast_manager::copy_families_plugins(ast_manager const & from) {
             if (m_family_manager.has_family(fid)) tout << get_family_id(fid_name) << "\n";);
       if (!m_family_manager.has_family(fid)) {
           family_id new_fid = mk_family_id(fid_name);
+          (void)new_fid;
           TRACE("copy_families_plugins", tout << "new target fid created: " << new_fid << " fid_name: " << fid_name << "\n";);
       }
       TRACE("copy_families_plugins", tout << "target fid: " << get_family_id(fid_name) << "\n";);

--- a/src/ast/datatype_decl_plugin.cpp
+++ b/src/ast/datatype_decl_plugin.cpp
@@ -462,7 +462,7 @@ func_decl * datatype_decl_plugin::mk_update_field(
     }
     range = domain[0];
     func_decl_info info(m_family_id, k, num_parameters, parameters);
-    return m.mk_func_decl(symbol("update_field"), arity, domain, range, info);
+    return m.mk_func_decl(symbol("update-field"), arity, domain, range, info);
 }
 
 func_decl * datatype_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, parameter const * parameters, 

--- a/src/ast/datatype_decl_plugin.h
+++ b/src/ast/datatype_decl_plugin.h
@@ -109,7 +109,7 @@ public:
          parameters[o]            - (int) m - number of constructors
          parameters[o+1]          - (int) k_1 - offset for constructor definition
          ...
-         parameters[o+m]          - (int) k_m - offset ofr constructor definition
+         parameters[o+m]          - (int) k_m - offset for constructor definition
       
          for each offset k_i at parameters[o+s] for some s in 0..m-1
          parameters[k_i]          - (symbol) name of the constructor

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -1178,10 +1178,10 @@ expr_ref fpa2bv_converter::mk_min_unspecified(func_decl * f, expr * x, expr * y)
     pn = m_util.mk_fp(decls.first, m_bv_util.mk_numeral(0, ebits), m_bv_util.mk_numeral(0, sbits - 1));
     np = m_util.mk_fp(decls.second, m_bv_util.mk_numeral(0, ebits), m_bv_util.mk_numeral(0, sbits - 1));
 
-    expr_ref x_is_pzero(m), x_is_nzero(m), xyzero(m);
+    expr_ref x_is_pzero(m), y_is_nzero(m), xyzero(m);
     mk_is_pzero(x, x_is_pzero);
-    mk_is_nzero(y, x_is_nzero);
-    m_simp.mk_and(x_is_pzero, x_is_nzero, xyzero);
+    mk_is_nzero(y, y_is_nzero);
+    m_simp.mk_and(x_is_pzero, y_is_nzero, xyzero);
     mk_ite(xyzero, pn, np, res);
 
     return res;
@@ -1259,10 +1259,10 @@ expr_ref fpa2bv_converter::mk_max_unspecified(func_decl * f, expr * x, expr * y)
     pn = m_util.mk_fp(decls.first, m_bv_util.mk_numeral(0, ebits), m_bv_util.mk_numeral(0, sbits - 1));
     np = m_util.mk_fp(decls.second, m_bv_util.mk_numeral(0, ebits), m_bv_util.mk_numeral(0, sbits - 1));
 
-    expr_ref x_is_pzero(m), x_is_nzero(m), xyzero(m);
+    expr_ref x_is_pzero(m), y_is_nzero(m), xyzero(m);
     mk_is_pzero(x, x_is_pzero);
-    mk_is_nzero(y, x_is_nzero);
-    m_simp.mk_and(x_is_pzero, x_is_nzero, xyzero);
+    mk_is_nzero(y, y_is_nzero);
+    m_simp.mk_and(x_is_pzero, y_is_nzero, xyzero);
     mk_ite(xyzero, pn, np, res);
 
     return res;

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -2235,14 +2235,17 @@ void fpa2bv_converter::mk_to_fp(func_decl * f, unsigned num, expr * const * args
     SASSERT(is_well_sorted(m, result));
 }
 
+
 void fpa2bv_converter::mk_to_fp_float(func_decl * f, sort * s, expr * rm, expr * x, expr_ref & result) {
+    SASSERT(is_app_of(rm, m_util.get_family_id(), OP_FPA_INTERNAL_RM));
+    mk_to_fp_float(s, to_app(rm)->get_arg(0), x, result);
+}
+
+void fpa2bv_converter::mk_to_fp_float(sort * to_srt, expr * rm, expr * x, expr_ref & result) {
     unsigned from_sbits = m_util.get_sbits(m.get_sort(x));
     unsigned from_ebits = m_util.get_ebits(m.get_sort(x));
-    unsigned to_sbits = m_util.get_sbits(s);
-    unsigned to_ebits = m_util.get_ebits(s);
-
-    SASSERT(is_app_of(rm, m_util.get_family_id(), OP_FPA_INTERNAL_RM));
-    expr * bv_rm = to_app(rm)->get_arg(0);
+    unsigned to_sbits = m_util.get_sbits(to_srt);
+    unsigned to_ebits = m_util.get_ebits(to_srt);
 
     if (from_sbits == to_sbits && from_ebits == to_ebits)
         result = x;
@@ -2253,20 +2256,20 @@ void fpa2bv_converter::mk_to_fp_float(func_decl * f, sort * s, expr * rm, expr *
 
         one1 = m_bv_util.mk_numeral(1, 1);
         expr_ref ninf(m), pinf(m);
-        mk_pinf(f, pinf);
-        mk_ninf(f, ninf);
+        mk_pinf(to_srt, pinf);
+        mk_ninf(to_srt, ninf);
 
         // NaN -> NaN
         mk_is_nan(x, c1);
-        mk_nan(f, v1);
+        mk_nan(to_srt, v1);
 
         // +0 -> +0
         mk_is_pzero(x, c2);
-        mk_pzero(f, v2);
+        mk_pzero(to_srt, v2);
 
         // -0 -> -0
         mk_is_nzero(x, c3);
-        mk_nzero(f, v3);
+        mk_nzero(to_srt, v3);
 
         // +oo -> +oo
         mk_is_pinf(x, c4);
@@ -2380,8 +2383,8 @@ void fpa2bv_converter::mk_to_fp_float(func_decl * f, sort * s, expr * rm, expr *
         dbg_decouple("fpa2bv_to_float_res_exp", res_exp);
 
         expr_ref rounded(m);
-        expr_ref rm_e(bv_rm, m);
-        round(s, rm_e, res_sgn, res_sig, res_exp, rounded);
+        expr_ref rm_e(rm, m);
+        round(to_srt, rm_e, res_sgn, res_sig, res_exp, rounded);
 
         expr_ref is_neg(m), sig_inf(m);
         m_simp.mk_eq(sgn, one1, is_neg);

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -1928,8 +1928,7 @@ void fpa2bv_converter::mk_round_to_integral(sort * s, expr_ref & rm, expr_ref & 
     tie_pttrn = m_bv_util.mk_concat(one_1, m_bv_util.mk_numeral(0, sbits-1));
     m_simp.mk_eq(rem, tie_pttrn, tie2);
     div_last = m_bv_util.mk_extract(0, 0, div);
-    tie2_c = m.mk_ite(tie2, m.mk_or(m.mk_and(rm_is_rte, m.mk_eq(div_last, one_1)),
-                                    m.mk_and(rm_is_rta, m.mk_eq(div_last, zero_1))),
+    tie2_c = m.mk_ite(tie2, m.mk_or(m.mk_and(rm_is_rte, m.mk_eq(div_last, one_1)), rm_is_rta),
                             m_bv_util.mk_ule(tie_pttrn, rem));
     m_simp.mk_ite(tie2_c, div_p1, div, v51);
 

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -79,7 +79,7 @@ void fpa2bv_converter::mk_eq(expr * a, expr * b, expr_ref & result) {
         m_simp.mk_or(both_are_nan, both_the_same, result);
     }
     else if (is_rm(a) && is_rm(b)) {
-        SASSERT(m_util.is_rm_bvwrap(b) && m_util.is_rm_bvwrap(a));
+        SASSERT(m_util.is_bv2rm(b) && m_util.is_bv2rm(a));
 
         TRACE("fpa2bv", tout << "mk_eq_rm a=" << mk_ismt2_pp(a, m) << std::endl;
                         tout << "mk_eq_rm b=" << mk_ismt2_pp(b, m) << std::endl;);
@@ -236,7 +236,7 @@ void fpa2bv_converter::mk_function_output(sort * rng, func_decl * fbv, expr * co
     else if (m_util.is_rm(rng)) {
         app_ref na(m);
         na = m.mk_app(fbv, fbv->get_arity(), new_args);
-        result = m_util.mk_rm(na);
+        result = m_util.mk_bv2rm(na);
     }
     else
         result = m.mk_app(fbv, fbv->get_arity(), new_args);
@@ -284,7 +284,7 @@ void fpa2bv_converter::mk_function(func_decl * f, unsigned num, expr * const * a
         bv_rng = m_bv_util.mk_sort(3);
         func_decl * bv_f = get_bv_uf(f, bv_rng, num);
         bv_app = m.mk_app(bv_f, num, args);
-        flt_app = m_util.mk_rm(bv_app);
+        flt_app = m_util.mk_bv2rm(bv_app);
         new_eq = m.mk_eq(fapp, flt_app);
         m_extra_assertions.push_back(new_eq);
         result = flt_app;
@@ -315,7 +315,7 @@ void fpa2bv_converter::mk_rm_const(func_decl * f, expr_ref & result) {
 #endif
             , m_bv_util.mk_sort(3));
 
-        result = m_util.mk_rm(bv3);
+        result = m_util.mk_bv2rm(bv3);
         m_rm_const2bv.insert(f, result);
         m.inc_ref(f);
         m.inc_ref(result);
@@ -522,7 +522,7 @@ void fpa2bv_converter::add_core(unsigned sbits, unsigned ebits,
 
 void fpa2bv_converter::mk_add(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 3);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
 
     expr_ref rm(m), x(m), y(m);
     rm = to_app(args[0])->get_arg(0);
@@ -692,7 +692,7 @@ void fpa2bv_converter::mk_neg(sort * srt, expr_ref & x, expr_ref & result) {
 
 void fpa2bv_converter::mk_mul(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 3);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
 
     expr_ref rm(m), x(m), y(m);
     rm = to_app(args[0])->get_arg(0);
@@ -842,7 +842,7 @@ void fpa2bv_converter::mk_mul(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
 
 void fpa2bv_converter::mk_div(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 3);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
     expr_ref rm(m), x(m), y(m);
     rm = to_app(args[0])->get_arg(0);
     x = args[1];
@@ -1239,7 +1239,7 @@ void fpa2bv_converter::mk_max_i(func_decl * f, unsigned num, expr * const * args
 
 void fpa2bv_converter::mk_fma(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 4);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
 
     // fusedma means (x * y) + z
     expr_ref rm(m), x(m), y(m), z(m);
@@ -1557,7 +1557,7 @@ void fpa2bv_converter::mk_fma(func_decl * f, unsigned num, expr * const * args, 
 
 void fpa2bv_converter::mk_sqrt(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 2);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
 
     expr_ref rm(m), x(m);
     rm = to_app(args[0])->get_arg(0);
@@ -1706,7 +1706,7 @@ void fpa2bv_converter::mk_sqrt(func_decl * f, unsigned num, expr * const * args,
 
 void fpa2bv_converter::mk_round_to_integral(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 2);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
 
     expr_ref rm(m), x(m);
     rm = to_app(args[0])->get_arg(0);
@@ -2166,7 +2166,7 @@ void fpa2bv_converter::mk_to_fp(func_decl * f, unsigned num, expr * const * args
 
 
 void fpa2bv_converter::mk_to_fp_float(func_decl * f, sort * s, expr * rm, expr * x, expr_ref & result) {
-    SASSERT(m_util.is_rm_bvwrap(rm));
+    SASSERT(m_util.is_bv2rm(rm));
     mk_to_fp_float(s, to_app(rm)->get_arg(0), x, result);
 }
 
@@ -2337,7 +2337,7 @@ void fpa2bv_converter::mk_to_fp_real(func_decl * f, sort * s, expr * rm, expr * 
         "x: " << mk_ismt2_pp(x, m) << std::endl;);
     SASSERT(m_util.is_float(s));
     SASSERT(au().is_real(x) || au().is_int(x));
-    SASSERT(m_util.is_rm_bvwrap(rm));
+    SASSERT(m_util.is_bv2rm(rm));
 
     expr * bv_rm = to_app(rm)->get_arg(0);
     unsigned ebits = m_util.get_ebits(s);
@@ -2472,7 +2472,7 @@ void fpa2bv_converter::mk_to_fp_real_int(func_decl * f, unsigned num, expr * con
     unsigned ebits = m_util.get_ebits(f->get_range());
     unsigned sbits = m_util.get_sbits(f->get_range());
 
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
     expr * bv_rm = to_app(args[0])->get_arg(0);
 
     rational e;
@@ -2630,7 +2630,7 @@ void fpa2bv_converter::mk_to_fp_signed(func_decl * f, unsigned num, expr * const
 
     SASSERT(num == 2);
     SASSERT(m_util.is_float(f->get_range()));
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
     SASSERT(m_bv_util.is_bv(args[1]));
 
     expr_ref rm(m), x(m);
@@ -2772,7 +2772,7 @@ void fpa2bv_converter::mk_to_fp_unsigned(func_decl * f, unsigned num, expr * con
 
     SASSERT(num == 2);
     SASSERT(m_util.is_float(f->get_range()));
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
     SASSERT(m_bv_util.is_bv(args[1]));
 
     expr_ref rm(m), x(m);
@@ -2924,7 +2924,7 @@ void fpa2bv_converter::mk_to_bv(func_decl * f, unsigned num, expr * const * args
         tout << "arg" << i << " = " << mk_ismt2_pp(args[i], m) << std::endl;);
 
     SASSERT(num == 2);
-    SASSERT(m_util.is_rm_bvwrap(args[0]));
+    SASSERT(m_util.is_bv2rm(args[0]));
     SASSERT(m_util.is_float(args[1]));
 
     expr * rm = to_app(args[0])->get_arg(0);
@@ -3528,7 +3528,7 @@ void fpa2bv_converter::mk_rounding_mode(decl_kind k, expr_ref & result)
     default: UNREACHABLE();
     }
 
-    result = m_util.mk_rm(result);
+    result = m_util.mk_bv2rm(result);
 }
 
 void fpa2bv_converter::dbg_decouple(const char * prefix, expr_ref & e) {

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -300,7 +300,7 @@ sort_ref fpa2bv_converter::replace_float_sorts(sort * s) {
                         has_news = true;
                     }
 
-                    accessor_decl * ad = mk_accessor_decl(name, type_ref(s1r));
+                    accessor_decl * ad = mk_accessor_decl(name, type_ref(s1r.get()));
                     new_cas.push_back(ad);
                 }
 
@@ -455,7 +455,6 @@ expr_ref fpa2bv_converter::replace_float_arg(expr * a) {
         break;
     case AST_QUANTIFIER: {
         quantifier * q = to_quantifier(a);
-        sort * const * srts = q->get_decl_sorts();
         vector<sort*> new_sorts;
         for (unsigned i = 0; q->get_num_decls(); i++) {
             sort_ref ns(m);

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -1156,13 +1156,13 @@ void fpa2bv_converter::mk_min_i(func_decl * f, unsigned num, expr * const * args
     SASSERT(is_well_sorted(m, result));
 }
 
-expr_ref fpa2bv_converter::mk_min_unspecified(func_decl * f, expr * x, expr * y) {
+expr_ref fpa2bv_converter::mk_min_max_unspecified(func_decl * f, expr * x, expr * y) {
     unsigned ebits = m_util.get_ebits(f->get_range());
     unsigned sbits = m_util.get_sbits(f->get_range());
     expr_ref res(m);
 
-    // The only cases in which min is unspecified for is when the arguments are +0.0 and -0.0.
-    // There is no "hardware interpretation" for fp.min.
+    // The only cases in which min/max is unspecified for is when the arguments are +0.0 and -0.0.
+    // There is no "hardware interpretation" for fp.min/fp.max.
 
     std::pair<app*, app*> decls(0, 0);
     if (!m_specials.find(f, decls)) {
@@ -1235,37 +1235,6 @@ void fpa2bv_converter::mk_max_i(func_decl * f, unsigned num, expr * const * args
     mk_ite(x_is_nan, y, result, result);
 
     SASSERT(is_well_sorted(m, result));
-}
-
-expr_ref fpa2bv_converter::mk_max_unspecified(func_decl * f, expr * x, expr * y) {
-    unsigned ebits = m_util.get_ebits(f->get_range());
-    unsigned sbits = m_util.get_sbits(f->get_range());
-    expr_ref res(m);
-
-    // The only cases in which max is unspecified for is when the arguments are +0.0 and -0.0.
-    // There is no "hardware interpretation" for fp.max.
-
-    std::pair<app*, app*> decls(0, 0);
-    if (!m_specials.find(f, decls)) {
-        decls.first = m.mk_fresh_const(0, m_bv_util.mk_sort(1));
-        decls.second = m.mk_fresh_const(0, m_bv_util.mk_sort(1));
-        m_specials.insert(f, decls);
-        m.inc_ref(f);
-        m.inc_ref(decls.first);
-        m.inc_ref(decls.second);
-    }
-
-    expr_ref pn(m), np(m);
-    pn = m_util.mk_fp(decls.first, m_bv_util.mk_numeral(0, ebits), m_bv_util.mk_numeral(0, sbits - 1));
-    np = m_util.mk_fp(decls.second, m_bv_util.mk_numeral(0, ebits), m_bv_util.mk_numeral(0, sbits - 1));
-
-    expr_ref x_is_pzero(m), y_is_nzero(m), xyzero(m);
-    mk_is_pzero(x, x_is_pzero);
-    mk_is_nzero(y, y_is_nzero);
-    m_simp.mk_and(x_is_pzero, y_is_nzero, xyzero);
-    mk_ite(xyzero, pn, np, res);
-
-    return res;
 }
 
 void fpa2bv_converter::mk_fma(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -144,6 +144,9 @@ public:
     void dbg_decouple(const char * prefix, expr_ref & e);
     expr_ref_vector m_extra_assertions;
 
+    bool is_special(func_decl * f) { return m_specials.contains(f); }
+    bool is_uf2bvuf(func_decl * f) { return m_uf2bvuf.contains(f); }
+
 protected:
     void mk_one(func_decl *f, expr_ref & sign, expr_ref & result);
 
@@ -201,6 +204,8 @@ private:
     void mk_div(sort * s, expr_ref & bv_rm, expr_ref & x, expr_ref & y, expr_ref & result);
     void mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & result);
     void mk_round_to_integral(sort * s, expr_ref & rm, expr_ref & x, expr_ref & result);
+
+    void mk_to_fp_float(sort * s, expr * rm, expr * x, expr_ref & result);
 };
 
 #endif

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -24,6 +24,11 @@ Notes:
 #include"ref_util.h"
 #include"fpa_decl_plugin.h"
 #include"bv_decl_plugin.h"
+#include"array_decl_plugin.h"
+#include"datatype_decl_plugin.h"
+#include"dl_decl_plugin.h"
+#include"pb_decl_plugin.h"
+#include"seq_decl_plugin.h"
 #include"basic_simplifier_plugin.h"
 
 class fpa2bv_converter {
@@ -33,6 +38,9 @@ protected:
     fpa_util                   m_util;
     bv_util                    m_bv_util;
     arith_util                 m_arith_util;
+    array_util                 m_array_util;
+    datatype_util              m_dt_util;
+    seq_util                   m_seq_util;
     mpf_manager              & m_mpf_manager;
     unsynch_mpz_manager      & m_mpz_manager;
     fpa_decl_plugin          * m_plugin;
@@ -41,6 +49,7 @@ protected:
     obj_map<func_decl, expr*>  m_const2bv;
     obj_map<func_decl, expr*>  m_rm_const2bv;
     obj_map<func_decl, func_decl*>  m_uf2bvuf;
+    obj_map<sort, sort*>       m_subst_sorts;
 
     obj_map<func_decl, std::pair<app *, app *> > m_specials;
 
@@ -145,7 +154,7 @@ public:
     expr_ref_vector m_extra_assertions;
 
     bool is_special(func_decl * f) { return m_specials.contains(f); }
-    bool is_uf2bvuf(func_decl * f) { return m_uf2bvuf.contains(f); }
+    bool is_uf2bvuf(func_decl * f) { return m_uf2bvuf.contains(f); }    
 
 protected:
     void mk_one(func_decl *f, expr_ref & sign, expr_ref & result);

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -133,11 +133,10 @@ public:
 
     void mk_min(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
     void mk_min_i(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
-    virtual expr_ref mk_min_unspecified(func_decl * f, expr * x, expr * y);
+    virtual expr_ref mk_min_max_unspecified(func_decl * f, expr * x, expr * y);
 
     void mk_max(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
     void mk_max_i(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
-    virtual expr_ref mk_max_unspecified(func_decl * f, expr * x, expr * y);
 
     expr_ref mk_to_ubv_unspecified(unsigned ebits, unsigned sbits, unsigned width);
     expr_ref mk_to_sbv_unspecified(unsigned ebits, unsigned sbits, unsigned width);

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -72,11 +72,11 @@ public:
     void mk_ite(expr * c, expr * t, expr * f, expr_ref & result);
     void mk_distinct(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
 
-    void mk_rounding_mode(func_decl * f, expr_ref & result);
+    void mk_rounding_mode(decl_kind k, expr_ref & result);
     void mk_numeral(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
     virtual void mk_const(func_decl * f, expr_ref & result);
     virtual void mk_rm_const(func_decl * f, expr_ref & result);
-    virtual void mk_uninterpreted_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
+    virtual void mk_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
     void mk_var(unsigned base_inx, sort * srt, expr_ref & result);
 
     void mk_pinf(func_decl * f, expr_ref & result);
@@ -186,7 +186,10 @@ protected:
 
     void mk_to_bv(func_decl * f, unsigned num, expr * const * args, bool is_signed, expr_ref & result);
 
-    void mk_uninterpreted_output(sort * rng, func_decl * fbv, expr_ref_buffer & new_args, expr_ref & result);
+    sort_ref replace_float_sorts(sort * s);
+    func_decl_ref replace_function(func_decl * f);
+    expr_ref replace_float_arg(expr * a);
+    void mk_function_output(sort * rng, func_decl * fbv, expr * const * new_args, expr_ref & result);
 
 private:
     void mk_nan(sort * s, expr_ref & result);

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -48,8 +48,7 @@ protected:
 
     obj_map<func_decl, expr*>  m_const2bv;
     obj_map<func_decl, expr*>  m_rm_const2bv;
-    obj_map<func_decl, func_decl*>  m_uf2bvuf;
-    obj_map<sort, sort*>       m_subst_sorts;
+    obj_map<func_decl, func_decl*>  m_uf2bvuf;    
 
     obj_map<func_decl, std::pair<app *, app *> > m_specials;
 
@@ -68,12 +67,9 @@ public:
     bool is_rm(expr * e) { return is_app(e) && m_util.is_rm(e); }
     bool is_rm(sort * s) { return m_util.is_rm(s); }
     bool is_float_family(func_decl * f) { return f->get_family_id() == m_util.get_family_id(); }
-
-    void mk_rm(expr * bv3, expr_ref & result);
-
-    void mk_fp(expr * sign, expr * exponent, expr * significand, expr_ref & result);
+    
     void mk_fp(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
-
+    
     void split_fp(expr * e, expr * & sgn, expr * & exp, expr * & sig) const;
     void split_fp(expr * e, expr_ref & sgn, expr_ref & exp, expr_ref & sig) const;
 
@@ -199,6 +195,7 @@ protected:
     func_decl_ref replace_function(func_decl * f);
     expr_ref replace_float_arg(expr * a);
     void mk_function_output(sort * rng, func_decl * fbv, expr * const * new_args, expr_ref & result);
+    func_decl * get_bv_uf(func_decl * f, sort * bv_rng, unsigned arity);
 
 private:
     void mk_nan(sort * s, expr_ref & result);

--- a/src/ast/fpa/fpa2bv_rewriter.cpp
+++ b/src/ast/fpa/fpa2bv_rewriter.cpp
@@ -156,7 +156,7 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
         case OP_FPA_INTERNAL_MAX_I: m_conv.mk_max_i(f, num, args, result); return BR_DONE;
 
         case OP_FPA_INTERNAL_BVWRAP:
-        case OP_FPA_INTERNAL_RM_BVWRAP:
+        case OP_FPA_INTERNAL_BV2RM:
         
         case OP_FPA_INTERNAL_TO_REAL_UNSPECIFIED:
         case OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED:

--- a/src/ast/fpa/fpa2bv_rewriter.cpp
+++ b/src/ast/fpa/fpa2bv_rewriter.cpp
@@ -150,8 +150,8 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
         case OP_FPA_MIN: m_conv.mk_min(f, num, args, result); return BR_REWRITE_FULL;
         case OP_FPA_MAX: m_conv.mk_max(f, num, args, result); return BR_REWRITE_FULL;
 
-        case OP_FPA_INTERNAL_MIN_UNSPECIFIED: result = m_conv.mk_min_unspecified(f, args[0], args[1]); return BR_DONE;
-        case OP_FPA_INTERNAL_MAX_UNSPECIFIED: result = m_conv.mk_max_unspecified(f, args[0], args[1]); return BR_DONE;
+        case OP_FPA_INTERNAL_MIN_UNSPECIFIED:
+        case OP_FPA_INTERNAL_MAX_UNSPECIFIED: result = m_conv.mk_min_max_unspecified(f, args[0], args[1]); return BR_DONE;
         case OP_FPA_INTERNAL_MIN_I: m_conv.mk_min_i(f, num, args, result); return BR_DONE;
         case OP_FPA_INTERNAL_MAX_I: m_conv.mk_max_i(f, num, args, result); return BR_DONE;
 

--- a/src/ast/fpa/fpa2bv_rewriter.cpp
+++ b/src/ast/fpa/fpa2bv_rewriter.cpp
@@ -71,7 +71,7 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
     if (m().is_eq(f)) {
         SASSERT(num == 2);
         TRACE("fpa2bv_rw", tout << "(= " << mk_ismt2_pp(args[0], m()) << " " <<
-              mk_ismt2_pp(args[1], m()) << ")" << std::endl;);
+            mk_ismt2_pp(args[1], m()) << ")" << std::endl;);
         SASSERT(m().get_sort(args[0]) == m().get_sort(args[1]));
         sort * ds = f->get_domain()[0];
         if (m_conv.is_float(ds)) {
@@ -83,7 +83,7 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
             return BR_DONE;
         }
         return BR_FAILED;
-    }
+    }    
     else if (m().is_ite(f)) {
         SASSERT(num == 3);
         if (m_conv.is_float(args[1])) {
@@ -100,7 +100,7 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
         }
         return BR_FAILED;
     }
-
+    
     if (m_conv.is_float_family(f)) {
         switch (f->get_decl_kind()) {
         case OP_FPA_RM_NEAREST_TIES_TO_AWAY:
@@ -166,16 +166,9 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
             NOT_IMPLEMENTED_YET();
         }
     }
-    else {
-        SASSERT(!m_conv.is_float_family(f));
-        bool is_float_uf = m_conv.is_float(f->get_range()) || m_conv.is_rm(f->get_range());
-        
-        for (unsigned i = 0; i < f->get_arity(); i++) {
-            sort * di = f->get_domain()[i];
-            is_float_uf |= m_conv.is_float(di) || m_conv.is_rm(di);
-        }
-
-        if (is_float_uf) {
+    else if (f->get_arity() > 0 && !m_conv.is_float_family(f)) {
+        expr_ref q(m().mk_app(f, num, args), m());
+        if (m_conv.fu().contains_floats(q)) {
             m_conv.mk_function(f, num, args, result);
             return BR_DONE;
         }
@@ -249,17 +242,16 @@ bool fpa2bv_rewriter_cfg::reduce_var(var * t, expr_ref & result, proof_ref & res
 
     expr_ref new_exp(m());
     sort * s = t->get_sort();
-    if (m_conv.is_float(s))
-        {
-            expr_ref new_var(m());
-            unsigned ebits = m_conv.fu().get_ebits(s);
-            unsigned sbits = m_conv.fu().get_sbits(s);
-            new_var = m().mk_var(t->get_idx(), m_conv.bu().mk_sort(sbits+ebits));
-            m_conv.mk_fp(m_conv.bu().mk_extract(sbits+ebits-1, sbits+ebits-1, new_var),
-                         m_conv.bu().mk_extract(ebits - 1, 0, new_var),
-                         m_conv.bu().mk_extract(sbits+ebits-2, ebits, new_var),
-                         new_exp);
-        }
+    if (m_conv.is_float(s)) {
+        expr_ref new_var(m());
+        unsigned ebits = m_conv.fu().get_ebits(s);
+        unsigned sbits = m_conv.fu().get_sbits(s);
+        new_var = m().mk_var(t->get_idx(), m_conv.bu().mk_sort(sbits+ebits));
+        m_conv.mk_fp(m_conv.bu().mk_extract(sbits+ebits-1, sbits+ebits-1, new_var),
+                        m_conv.bu().mk_extract(ebits - 1, 0, new_var),
+                        m_conv.bu().mk_extract(sbits+ebits-2, ebits, new_var),
+                        new_exp);
+    }
     else
         new_exp = m().mk_var(t->get_idx(), s);
 

--- a/src/ast/fpa/fpa2bv_rewriter.cpp
+++ b/src/ast/fpa/fpa2bv_rewriter.cpp
@@ -56,7 +56,10 @@ bool fpa2bv_rewriter_cfg::max_steps_exceeded(unsigned num_steps) const {
 
 
 br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * const * args, expr_ref & result, proof_ref & result_pr) {
-    TRACE("fpa2bv_rw", tout << "APP: " << f->get_name() << std::endl; );
+    TRACE("fpa2bv_rw", tout << "func: " << f->get_name() << std::endl;
+                       tout << "args: " << std::endl;
+                       for (unsigned i = 0; i < num; i++)
+                           tout << mk_ismt2_pp(args[i], m()) << std::endl;);
 
     if (num == 0 && f->get_family_id() == null_family_id && m_conv.is_float(f->get_range())) {
         m_conv.mk_const(f, result);
@@ -166,12 +169,11 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
             NOT_IMPLEMENTED_YET();
         }
     }
-    else if (f->get_arity() > 0 && !m_conv.is_float_family(f)) {
-        expr_ref q(m().mk_app(f, num, args), m());
-        if (m_conv.fu().contains_floats(q)) {
-            m_conv.mk_function(f, num, args, result);
-            return BR_DONE;
-        }
+    else 
+    {
+        SASSERT(!m_conv.is_float_family(f));
+        m_conv.mk_function(f, num, args, result);
+        return BR_DONE;
     }
 
     return BR_FAILED;
@@ -247,10 +249,9 @@ bool fpa2bv_rewriter_cfg::reduce_var(var * t, expr_ref & result, proof_ref & res
         unsigned ebits = m_conv.fu().get_ebits(s);
         unsigned sbits = m_conv.fu().get_sbits(s);
         new_var = m().mk_var(t->get_idx(), m_conv.bu().mk_sort(sbits+ebits));
-        m_conv.mk_fp(m_conv.bu().mk_extract(sbits+ebits-1, sbits+ebits-1, new_var),
-                        m_conv.bu().mk_extract(ebits - 1, 0, new_var),
-                        m_conv.bu().mk_extract(sbits+ebits-2, ebits, new_var),
-                        new_exp);
+        new_exp = m_conv.fu().mk_fp(m_conv.bu().mk_extract(sbits+ebits-1, sbits+ebits-1, new_var),
+                                    m_conv.bu().mk_extract(ebits - 1, 0, new_var),
+                                    m_conv.bu().mk_extract(sbits+ebits-2, ebits, new_var));
     }
     else
         new_exp = m().mk_var(t->get_idx(), s);

--- a/src/ast/fpa/fpa2bv_rewriter.cpp
+++ b/src/ast/fpa/fpa2bv_rewriter.cpp
@@ -107,7 +107,7 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
         case OP_FPA_RM_NEAREST_TIES_TO_EVEN:
         case OP_FPA_RM_TOWARD_NEGATIVE:
         case OP_FPA_RM_TOWARD_POSITIVE:
-        case OP_FPA_RM_TOWARD_ZERO: m_conv.mk_rounding_mode(f, result); return BR_DONE;
+        case OP_FPA_RM_TOWARD_ZERO: m_conv.mk_rounding_mode(f->get_decl_kind(), result); return BR_DONE;
         case OP_FPA_NUM: m_conv.mk_numeral(f, num, args, result); return BR_DONE;
         case OP_FPA_PLUS_INF: m_conv.mk_pinf(f, result); return BR_DONE;
         case OP_FPA_MINUS_INF: m_conv.mk_ninf(f, result); return BR_DONE;
@@ -152,9 +152,9 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
         case OP_FPA_INTERNAL_MIN_I: m_conv.mk_min_i(f, num, args, result); return BR_DONE;
         case OP_FPA_INTERNAL_MAX_I: m_conv.mk_max_i(f, num, args, result); return BR_DONE;
 
-        case OP_FPA_INTERNAL_RM:
         case OP_FPA_INTERNAL_BVWRAP:
-        case OP_FPA_INTERNAL_BVUNWRAP:
+        case OP_FPA_INTERNAL_RM_BVWRAP:
+        
         case OP_FPA_INTERNAL_TO_REAL_UNSPECIFIED:
         case OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED:
         case OP_FPA_INTERNAL_TO_SBV_UNSPECIFIED:
@@ -169,14 +169,14 @@ br_status fpa2bv_rewriter_cfg::reduce_app(func_decl * f, unsigned num, expr * co
     else {
         SASSERT(!m_conv.is_float_family(f));
         bool is_float_uf = m_conv.is_float(f->get_range()) || m_conv.is_rm(f->get_range());
-
+        
         for (unsigned i = 0; i < f->get_arity(); i++) {
             sort * di = f->get_domain()[i];
             is_float_uf |= m_conv.is_float(di) || m_conv.is_rm(di);
         }
 
         if (is_float_uf) {
-            m_conv.mk_uninterpreted_function(f, num, args, result);
+            m_conv.mk_function(f, num, args, result);
             return BR_DONE;
         }
     }

--- a/src/ast/fpa_decl_plugin.cpp
+++ b/src/ast/fpa_decl_plugin.cpp
@@ -711,18 +711,6 @@ func_decl * fpa_decl_plugin::mk_internal_bv_wrap(decl_kind k, unsigned num_param
     }
 }
 
-func_decl * fpa_decl_plugin::mk_internal_bv_unwrap(decl_kind k, unsigned num_parameters, parameter const * parameters,
-                                                     unsigned arity, sort * const * domain, sort * range) {
-    if (arity != 1)
-        m_manager->raise_exception("invalid number of arguments to bv_unwrap");
-    if (!is_sort_of(domain[0], m_bv_fid, BV_SORT))
-        m_manager->raise_exception("sort mismatch, expected argument of bitvector sort");
-    if (!is_float_sort(range) && !is_rm_sort(range))
-        m_manager->raise_exception("sort mismatch, expected range of FloatingPoint or RoundingMode sort");
-
-    return m_manager->mk_func_decl(symbol("bv_unwrap"), 1, domain, range, func_decl_info(m_family_id, k, num_parameters, parameters));
-}
-
 func_decl * fpa_decl_plugin::mk_internal_to_ubv_unspecified(
     decl_kind k, unsigned num_parameters, parameter const * parameters,
     unsigned arity, sort * const * domain, sort * range) {
@@ -847,12 +835,10 @@ func_decl * fpa_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, 
     case OP_FPA_TO_IEEE_BV:
         return mk_to_ieee_bv(k, num_parameters, parameters, arity, domain, range);
 
-    case OP_FPA_INTERNAL_RM:
-        return mk_internal_rm(k, num_parameters, parameters, arity, domain, range);
     case OP_FPA_INTERNAL_BVWRAP:
-        return mk_internal_bv_wrap(k, num_parameters, parameters, arity, domain, range);
-    case OP_FPA_INTERNAL_BVUNWRAP:
-        return mk_internal_bv_unwrap(k, num_parameters, parameters, arity, domain, range);
+        return mk_internal_bv_wrap(k, num_parameters, parameters, arity, domain, range);    
+    case OP_FPA_INTERNAL_RM_BVWRAP:
+        return mk_internal_rm(k, num_parameters, parameters, arity, domain, range);
 
     case OP_FPA_INTERNAL_MIN_I:
     case OP_FPA_INTERNAL_MAX_I:
@@ -1027,12 +1013,12 @@ sort * fpa_util::mk_float_sort(unsigned ebits, unsigned sbits) {
     return m().mk_sort(m_fid, FLOATING_POINT_SORT, 2, ps);
 }
 
-unsigned fpa_util::get_ebits(sort * s) {
+unsigned fpa_util::get_ebits(sort * s) const {
     SASSERT(is_float(s));
     return static_cast<unsigned>(s->get_parameter(0).get_int());
 }
 
-unsigned fpa_util::get_sbits(sort * s) {
+unsigned fpa_util::get_sbits(sort * s) const {
     SASSERT(is_float(s));
     return static_cast<unsigned>(s->get_parameter(1).get_int());
 }

--- a/src/ast/fpa_decl_plugin.cpp
+++ b/src/ast/fpa_decl_plugin.cpp
@@ -676,7 +676,7 @@ func_decl * fpa_decl_plugin::mk_to_ieee_bv(decl_kind k, unsigned num_parameters,
     return m_manager->mk_func_decl(name, 1, domain, bv_srt, func_decl_info(m_family_id, k));
 }
 
-func_decl * fpa_decl_plugin::mk_internal_rm(decl_kind k, unsigned num_parameters, parameter const * parameters,
+func_decl * fpa_decl_plugin::mk_internal_bv2rm(decl_kind k, unsigned num_parameters, parameter const * parameters,
                                             unsigned arity, sort * const * domain, sort * range) {
     if (arity != 1)
         m_manager->raise_exception("invalid number of arguments to internal_rm");
@@ -837,8 +837,8 @@ func_decl * fpa_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, 
 
     case OP_FPA_INTERNAL_BVWRAP:
         return mk_internal_bv_wrap(k, num_parameters, parameters, arity, domain, range);    
-    case OP_FPA_INTERNAL_RM_BVWRAP:
-        return mk_internal_rm(k, num_parameters, parameters, arity, domain, range);
+    case OP_FPA_INTERNAL_BV2RM:
+        return mk_internal_bv2rm(k, num_parameters, parameters, arity, domain, range);
 
     case OP_FPA_INTERNAL_MIN_I:
     case OP_FPA_INTERNAL_MAX_I:

--- a/src/ast/fpa_decl_plugin.h
+++ b/src/ast/fpa_decl_plugin.h
@@ -370,7 +370,9 @@ public:
     bool is_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_BVWRAP); }
     bool is_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_BVWRAP; }
     bool is_rm_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_RM_BVWRAP); }
-    bool is_rm_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_RM_BVWRAP; }
+    bool is_rm_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_RM_BVWRAP; }    
+
+    bool contains_floats(ast * a);
 };
 
 #endif

--- a/src/ast/fpa_decl_plugin.h
+++ b/src/ast/fpa_decl_plugin.h
@@ -297,7 +297,7 @@ public:
     app * mk_fp(expr * sgn, expr * exp, expr * sig) { 
         SASSERT(m_bv_util.is_bv(sgn) && m_bv_util.get_bv_size(sgn) == 1);
         SASSERT(m_bv_util.is_bv(exp));
-        SASSERT(m_bv_util.is_bv(sig));
+        SASSERT(m_bv_util.is_bv(sig));        
         return m().mk_app(m_fid, OP_FPA_FP, sgn, exp, sig); 
     }
     
@@ -382,6 +382,24 @@ public:
     bool is_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_BVWRAP; }
     bool is_rm_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_RM_BVWRAP); }
     bool is_rm_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_RM_BVWRAP; }    
+
+    bool is_min_interpreted(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_MIN_I); }
+    bool is_min_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_MIN_UNSPECIFIED); }
+    bool is_max_interpreted(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_MAX_I); }
+    bool is_max_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_MAX_UNSPECIFIED); }
+    bool is_to_ubv_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED); }
+    bool is_to_sbv_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_TO_SBV_UNSPECIFIED); }
+    bool is_to_ieee_bv_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_TO_IEEE_BV_UNSPECIFIED); }
+    bool is_to_real_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_TO_REAL_UNSPECIFIED); }
+
+    bool is_min_interpreted(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_MIN_I; }
+    bool is_min_unspecified(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_MIN_UNSPECIFIED; }
+    bool is_max_interpreted(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_MAX_I; }
+    bool is_max_unspecified(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_MAX_UNSPECIFIED; }
+    bool is_to_ubv_unspecified(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED; }
+    bool is_to_sbv_unspecified(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_TO_SBV_UNSPECIFIED; }
+    bool is_to_ieee_bv_unspecified(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_TO_IEEE_BV_UNSPECIFIED; }
+    bool is_to_real_unspecified(func_decl * f) { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_TO_REAL_UNSPECIFIED; }
 
     bool contains_floats(ast * a);
 };

--- a/src/ast/fpa_decl_plugin.h
+++ b/src/ast/fpa_decl_plugin.h
@@ -88,7 +88,7 @@ enum fpa_op_kind {
 
     /* Internal use only */
     OP_FPA_INTERNAL_BVWRAP,
-    OP_FPA_INTERNAL_RM_BVWRAP, // Internal conversion from (_ BitVec 3) to RoundingMode
+    OP_FPA_INTERNAL_BV2RM,
 
     OP_FPA_INTERNAL_MIN_I,
     OP_FPA_INTERNAL_MAX_I,
@@ -164,8 +164,8 @@ class fpa_decl_plugin : public decl_plugin {
     func_decl * mk_to_ieee_bv(decl_kind k, unsigned num_parameters, parameter const * parameters,
                               unsigned arity, sort * const * domain, sort * range);
 
-    func_decl * mk_internal_rm(decl_kind k, unsigned num_parameters, parameter const * parameters,
-                               unsigned arity, sort * const * domain, sort * range);
+    func_decl * mk_internal_bv2rm(decl_kind k, unsigned num_parameters, parameter const * parameters,
+                                  unsigned arity, sort * const * domain, sort * range);
     func_decl * mk_internal_bv_wrap(decl_kind k, unsigned num_parameters, parameter const * parameters,
                                     unsigned arity, sort * const * domain, sort * range);
     func_decl * mk_internal_bv_unwrap(decl_kind k, unsigned num_parameters, parameter const * parameters,
@@ -301,11 +301,6 @@ public:
         return m().mk_app(m_fid, OP_FPA_FP, sgn, exp, sig); 
     }
     
-    app * mk_rm(expr * bv3) { 
-        SASSERT(m_bv_util.is_bv(bv3) && m_bv_util.get_bv_size(bv3) == 3);
-        return m().mk_app(m_fid, OP_FPA_INTERNAL_RM_BVWRAP, 0, 0, 1, &bv3, mk_rm_sort());
-    }
-
     app * mk_to_fp(sort * s, expr * bv_t) {
         SASSERT(is_float(s) && s->get_num_parameters() == 2);
         return m().mk_app(m_fid, OP_FPA_TO_FP, 2, s->get_parameters(), 1, &bv_t);
@@ -373,6 +368,10 @@ public:
 
     app * mk_to_ieee_bv(expr * arg1) { return m().mk_app(m_fid, OP_FPA_TO_IEEE_BV, arg1); }
 
+    app * mk_bv2rm(expr * bv3) {
+        SASSERT(m_bv_util.is_bv(bv3) && m_bv_util.get_bv_size(bv3) == 3);
+        return m().mk_app(m_fid, OP_FPA_INTERNAL_BV2RM, 0, 0, 1, &bv3, mk_rm_sort());
+    }
     app * mk_internal_to_ubv_unspecified(unsigned ebits, unsigned sbits, unsigned width);
     app * mk_internal_to_sbv_unspecified(unsigned ebits, unsigned sbits, unsigned width);
     app * mk_internal_to_ieee_bv_unspecified(unsigned ebits, unsigned sbits);
@@ -380,8 +379,8 @@ public:
 
     bool is_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_BVWRAP); }
     bool is_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_BVWRAP; }
-    bool is_rm_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_RM_BVWRAP); }
-    bool is_rm_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_RM_BVWRAP; }    
+    bool is_bv2rm(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_BV2RM); }
+    bool is_bv2rm(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_BV2RM; }
 
     bool is_min_interpreted(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_MIN_I); }
     bool is_min_unspecified(expr * e) { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_MIN_UNSPECIFIED); }

--- a/src/ast/fpa_decl_plugin.h
+++ b/src/ast/fpa_decl_plugin.h
@@ -87,9 +87,8 @@ enum fpa_op_kind {
     OP_FPA_TO_IEEE_BV,
 
     /* Internal use only */
-    OP_FPA_INTERNAL_RM, // Internal conversion from (_ BitVec 3) to RoundingMode
     OP_FPA_INTERNAL_BVWRAP,
-    OP_FPA_INTERNAL_BVUNWRAP,
+    OP_FPA_INTERNAL_RM_BVWRAP, // Internal conversion from (_ BitVec 3) to RoundingMode
 
     OP_FPA_INTERNAL_MIN_I,
     OP_FPA_INTERNAL_MAX_I,
@@ -256,12 +255,13 @@ public:
 
     sort * mk_float_sort(unsigned ebits, unsigned sbits);
     sort * mk_rm_sort() { return m().mk_sort(m_fid, ROUNDING_MODE_SORT); }
-    bool is_float(sort * s) { return is_sort_of(s, m_fid, FLOATING_POINT_SORT); }
-    bool is_rm(sort * s) { return is_sort_of(s, m_fid, ROUNDING_MODE_SORT); }
-    bool is_float(expr * e) { return is_float(m_manager.get_sort(e)); }
-    bool is_rm(expr * e) { return is_rm(m_manager.get_sort(e)); }
-    unsigned get_ebits(sort * s);
-    unsigned get_sbits(sort * s);
+    bool is_float(sort * s) const { return is_sort_of(s, m_fid, FLOATING_POINT_SORT); }
+    bool is_rm(sort * s) const { return is_sort_of(s, m_fid, ROUNDING_MODE_SORT); }
+    bool is_float(expr * e) const { return is_float(m_manager.get_sort(e)); }
+    bool is_rm(expr * e) const { return is_rm(m_manager.get_sort(e)); }
+    bool is_fp(expr * e) const { return is_app_of(e, m_fid, OP_FPA_FP); }    
+    unsigned get_ebits(sort * s) const;
+    unsigned get_sbits(sort * s) const;
 
     app * mk_round_nearest_ties_to_even() { return m().mk_const(m_fid, OP_FPA_RM_NEAREST_TIES_TO_EVEN); }
     app * mk_round_nearest_ties_to_away() { return m().mk_const(m_fid, OP_FPA_RM_NEAREST_TIES_TO_AWAY); }
@@ -367,8 +367,10 @@ public:
     app * mk_internal_to_ieee_bv_unspecified(unsigned ebits, unsigned sbits);
     app * mk_internal_to_real_unspecified(unsigned ebits, unsigned sbits);
 
-    bool is_wrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_BVWRAP); }
-    bool is_unwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_BVUNWRAP); }
+    bool is_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_BVWRAP); }
+    bool is_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_BVWRAP; }
+    bool is_rm_bvwrap(expr * e) const { return is_app_of(e, get_family_id(), OP_FPA_INTERNAL_RM_BVWRAP); }
+    bool is_rm_bvwrap(func_decl * f) const { return f->get_family_id() == get_family_id() && f->get_decl_kind() == OP_FPA_INTERNAL_RM_BVWRAP; }
 };
 
 #endif

--- a/src/ast/fpa_decl_plugin.h
+++ b/src/ast/fpa_decl_plugin.h
@@ -294,7 +294,18 @@ public:
     bool is_pzero(expr * n) { scoped_mpf v(fm()); return is_numeral(n, v) && fm().is_pzero(v); }
     bool is_nzero(expr * n) { scoped_mpf v(fm()); return is_numeral(n, v) && fm().is_nzero(v); }
 
-    app * mk_fp(expr * sgn, expr * exp, expr * sig) { return m().mk_app(m_fid, OP_FPA_FP, sgn, exp, sig); }
+    app * mk_fp(expr * sgn, expr * exp, expr * sig) { 
+        SASSERT(m_bv_util.is_bv(sgn) && m_bv_util.get_bv_size(sgn) == 1);
+        SASSERT(m_bv_util.is_bv(exp));
+        SASSERT(m_bv_util.is_bv(sig));
+        return m().mk_app(m_fid, OP_FPA_FP, sgn, exp, sig); 
+    }
+    
+    app * mk_rm(expr * bv3) { 
+        SASSERT(m_bv_util.is_bv(bv3) && m_bv_util.get_bv_size(bv3) == 3);
+        return m().mk_app(m_fid, OP_FPA_INTERNAL_RM_BVWRAP, 0, 0, 1, &bv3, mk_rm_sort());
+    }
+
     app * mk_to_fp(sort * s, expr * bv_t) {
         SASSERT(is_float(s) && s->get_num_parameters() == 2);
         return m().mk_app(m_fid, OP_FPA_TO_FP, 2, s->get_parameters(), 1, &bv_t);

--- a/src/ast/normal_forms/nnf.cpp
+++ b/src/ast/normal_forms/nnf.cpp
@@ -200,14 +200,14 @@ typedef default_exception nnf_exception;
 struct nnf::imp {
 
     struct frame {
-        expr *    m_curr;
+        expr_ref  m_curr;
         unsigned  m_i:28;
         unsigned  m_pol:1;  // pos/neg polarity
         unsigned  m_in_q:1; // true if m_curr is nested in a quantifier
         unsigned  m_new_child:1; 
         unsigned  m_cache_result:1;
         unsigned  m_spos;   // top of the result stack, when the frame was created.
-        frame(expr * n, bool pol, bool in_q, bool cache_res, unsigned spos):
+        frame(expr_ref& n, bool pol, bool in_q, bool cache_res, unsigned spos):
             m_curr(n),
             m_i(0),
             m_pol(pol),
@@ -225,7 +225,7 @@ struct nnf::imp {
 #define POS_Q_CIDX  3   // positive polarity and nested in a quantifier
     
     ast_manager &          m_manager;
-    svector<frame>         m_frame_stack;
+    vector<frame>          m_frame_stack;
     expr_ref_vector        m_result_stack;
     
     typedef act_cache      cache;
@@ -324,7 +324,8 @@ struct nnf::imp {
     }
 
     void push_frame(expr * t, bool pol, bool in_q, bool cache_res) {
-        m_frame_stack.push_back(frame(t, pol, in_q, cache_res, m_result_stack.size()));
+        expr_ref tr(t, m());
+        m_frame_stack.push_back(frame(tr, pol, in_q, cache_res, m_result_stack.size()));
     }
 
     static unsigned get_cache_idx(bool pol, bool in_q) { 

--- a/src/ast/rewriter/bv_trailing.cpp
+++ b/src/ast/rewriter/bv_trailing.cpp
@@ -67,9 +67,10 @@ struct bv_trailing::imp {
         }
         expr_ref out1(m);
         expr_ref out2(m);
-        const unsigned rm1 = remove_trailing(e1, min, out1, TRAILING_DEPTH);
-        const unsigned rm2 = remove_trailing(e2, min, out2, TRAILING_DEPTH);
-        SASSERT(rm1 == min && rm2 == min);
+        DEBUG_CODE(
+            const unsigned rm1 = remove_trailing(e1, min, out1, TRAILING_DEPTH);
+            const unsigned rm2 = remove_trailing(e2, min, out2, TRAILING_DEPTH);
+            SASSERT(rm1 == min && rm2 == min););
         const bool are_eq = m.are_equal(out1, out2);
         result = are_eq ? m.mk_true() : m.mk_eq(out1, out2);
         return are_eq ? BR_DONE : BR_REWRITE2;
@@ -122,9 +123,8 @@ struct bv_trailing::imp {
         expr_ref tmp(m);
         for (unsigned i = 0; i < num; ++i) {
             expr * const curr = a->get_arg(i);
-            const unsigned crm = remove_trailing(curr, to_rm, tmp, depth - 1);
+            VERIFY(to_rm == remove_trailing(curr, to_rm, tmp, depth - 1));
             new_args.push_back(tmp);
-            SASSERT(crm == to_rm);
         }
         result = m.mk_app(m_util.get_fid(), OP_BADD, new_args.size(), new_args.c_ptr());
         return to_rm;

--- a/src/ast/rewriter/fpa_rewriter.cpp
+++ b/src/ast/rewriter/fpa_rewriter.cpp
@@ -100,7 +100,7 @@ br_status fpa_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         SASSERT(num_args == 2); st = BR_FAILED; break;
     
     case OP_FPA_INTERNAL_BVWRAP: SASSERT(num_args == 1); st = mk_bvwrap(args[0], result); break;
-    case OP_FPA_INTERNAL_RM_BVWRAP:SASSERT(num_args == 1); st = mk_rm(args[0], result); break;
+    case OP_FPA_INTERNAL_BV2RM: SASSERT(num_args == 1); st = mk_bv2rm(args[0], result); break;
 
     case OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED:
     case OP_FPA_INTERNAL_TO_SBV_UNSPECIFIED:
@@ -719,7 +719,7 @@ br_status fpa_rewriter::mk_eq_core(expr * arg1, expr * arg2, expr_ref & result) 
     return BR_FAILED;
 }
 
-br_status fpa_rewriter::mk_rm(expr * arg, expr_ref & result) {
+br_status fpa_rewriter::mk_bv2rm(expr * arg, expr_ref & result) {
     bv_util bu(m());
     rational bv_val;
     unsigned sz = 0;

--- a/src/ast/rewriter/fpa_rewriter.cpp
+++ b/src/ast/rewriter/fpa_rewriter.cpp
@@ -109,8 +109,6 @@ br_status fpa_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         st = BR_FAILED;
         break;
 
-        
-
     default:
         NOT_IMPLEMENTED_YET();
     }
@@ -892,7 +890,6 @@ br_status fpa_rewriter::mk_to_real(expr * arg, expr_ref & result) {
     return BR_FAILED;
 }
 
-
 br_status fpa_rewriter::mk_bvwrap(expr * arg, expr_ref & result) {
     if (is_app_of(arg, m_util.get_family_id(), OP_FPA_FP)) {
         bv_util bu(m());
@@ -923,10 +920,3 @@ br_status fpa_rewriter::mk_bvwrap(expr * arg, expr_ref & result) {
 
     return BR_FAILED;
 }
-
-//br_status fpa_rewriter::mk_bvunwrap(expr * arg, expr_ref & result) {
-//    if (is_app_of(arg, m_util.get_family_id(), OP_FPA_INTERNAL_BVWRAP))
-//        result = to_app(arg)->get_arg(0);
-//    
-//    return BR_FAILED;
-//}

--- a/src/ast/rewriter/fpa_rewriter.cpp
+++ b/src/ast/rewriter/fpa_rewriter.cpp
@@ -98,9 +98,10 @@ br_status fpa_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
     case OP_FPA_INTERNAL_MIN_UNSPECIFIED:
     case OP_FPA_INTERNAL_MAX_UNSPECIFIED:
         SASSERT(num_args == 2); st = BR_FAILED; break;
+    
+    case OP_FPA_INTERNAL_BVWRAP: SASSERT(num_args == 1); st = mk_bvwrap(args[0], result); break;
+    case OP_FPA_INTERNAL_RM_BVWRAP:SASSERT(num_args == 1); st = mk_rm(args[0], result); break;
 
-    case OP_FPA_INTERNAL_RM:
-        SASSERT(num_args == 1);  SASSERT(num_args == 1); st = mk_rm(args[0], result); break;
     case OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED:
     case OP_FPA_INTERNAL_TO_SBV_UNSPECIFIED:
     case OP_FPA_INTERNAL_TO_REAL_UNSPECIFIED:
@@ -108,8 +109,7 @@ br_status fpa_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         st = BR_FAILED;
         break;
 
-    case OP_FPA_INTERNAL_BVWRAP: SASSERT(num_args == 1); st = mk_bvwrap(args[0], result); break;
-    case OP_FPA_INTERNAL_BVUNWRAP: SASSERT(num_args == 1); st = mk_bvunwrap(args[0], result); break;
+        
 
     default:
         NOT_IMPLEMENTED_YET();
@@ -924,9 +924,9 @@ br_status fpa_rewriter::mk_bvwrap(expr * arg, expr_ref & result) {
     return BR_FAILED;
 }
 
-br_status fpa_rewriter::mk_bvunwrap(expr * arg, expr_ref & result) {
-    if (is_app_of(arg, m_util.get_family_id(), OP_FPA_INTERNAL_BVWRAP))
-        result = to_app(arg)->get_arg(0);
-    
-    return BR_FAILED;
-}
+//br_status fpa_rewriter::mk_bvunwrap(expr * arg, expr_ref & result) {
+//    if (is_app_of(arg, m_util.get_family_id(), OP_FPA_INTERNAL_BVWRAP))
+//        result = to_app(arg)->get_arg(0);
+//    
+//    return BR_FAILED;
+//}

--- a/src/ast/rewriter/fpa_rewriter.cpp
+++ b/src/ast/rewriter/fpa_rewriter.cpp
@@ -100,17 +100,16 @@ br_status fpa_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         SASSERT(num_args == 2); st = BR_FAILED; break;
 
     case OP_FPA_INTERNAL_RM:
-        SASSERT(num_args == 1); st = mk_rm(args[0], result); break;
+        SASSERT(num_args == 1);  SASSERT(num_args == 1); st = mk_rm(args[0], result); break;
     case OP_FPA_INTERNAL_TO_UBV_UNSPECIFIED:
     case OP_FPA_INTERNAL_TO_SBV_UNSPECIFIED:
     case OP_FPA_INTERNAL_TO_REAL_UNSPECIFIED:
     case OP_FPA_INTERNAL_TO_IEEE_BV_UNSPECIFIED:
         st = BR_FAILED;
-
-    case OP_FPA_INTERNAL_BVWRAP:
-    case OP_FPA_INTERNAL_BVUNWRAP:
-        st = BR_FAILED;
         break;
+
+    case OP_FPA_INTERNAL_BVWRAP: SASSERT(num_args == 1); st = mk_bvwrap(args[0], result); break;
+    case OP_FPA_INTERNAL_BVUNWRAP: SASSERT(num_args == 1); st = mk_bvunwrap(args[0], result); break;
 
     default:
         NOT_IMPLEMENTED_YET();
@@ -890,5 +889,44 @@ br_status fpa_rewriter::mk_to_real(expr * arg, expr_ref & result) {
         return BR_DONE;
     }
 
+    return BR_FAILED;
+}
+
+
+br_status fpa_rewriter::mk_bvwrap(expr * arg, expr_ref & result) {
+    if (is_app_of(arg, m_util.get_family_id(), OP_FPA_FP)) {
+        bv_util bu(m());
+        SASSERT(to_app(arg)->get_num_args() == 3);
+        sort_ref fpsrt(m());
+        fpsrt = to_app(arg)->get_decl()->get_range();
+        expr_ref a0(m()), a1(m()), a2(m());
+        a0 = to_app(arg)->get_arg(0);
+        a1 = to_app(arg)->get_arg(1);
+        a2 = to_app(arg)->get_arg(2);
+        if (bu.is_extract(a0) && bu.is_extract(a1) && bu.is_extract(a2)) {
+            unsigned w0 = bu.get_extract_high(a0) - bu.get_extract_low(a0) + 1;
+            unsigned w1 = bu.get_extract_high(a1) - bu.get_extract_low(a1) + 1;
+            unsigned w2 = bu.get_extract_high(a2) - bu.get_extract_low(a2) + 1;
+            unsigned cw = w0 + w1 + w2;
+            if (cw == m_util.get_ebits(fpsrt) + m_util.get_sbits(fpsrt)) {
+                expr_ref aa0(m()), aa1(m()), aa2(m());
+                aa0 = to_app(a0)->get_arg(0);
+                aa1 = to_app(a1)->get_arg(0);
+                aa2 = to_app(a2)->get_arg(0);
+                if (aa0 == aa1 && aa1 == aa2 && bu.get_bv_size(aa0) == cw) {
+                    result = aa0;
+                    return BR_DONE;
+                }
+            }
+        }
+    }
+
+    return BR_FAILED;
+}
+
+br_status fpa_rewriter::mk_bvunwrap(expr * arg, expr_ref & result) {
+    if (is_app_of(arg, m_util.get_family_id(), OP_FPA_INTERNAL_BVWRAP))
+        result = to_app(arg)->get_arg(0);
+    
     return BR_FAILED;
 }

--- a/src/ast/rewriter/fpa_rewriter.h
+++ b/src/ast/rewriter/fpa_rewriter.h
@@ -89,6 +89,9 @@ public:
     br_status mk_to_ubv_unspecified(unsigned ebits, unsigned sbits, unsigned with, expr_ref & result);
     br_status mk_to_sbv_unspecified(unsigned ebits, unsigned sbits, unsigned with, expr_ref & result);
     br_status mk_to_real_unspecified(unsigned ebits, unsigned sbits, expr_ref & result);
+
+    br_status mk_bvwrap(expr * arg, expr_ref & result);
+    br_status mk_bvunwrap(expr * arg, expr_ref & result);
 };
 
 #endif

--- a/src/ast/rewriter/fpa_rewriter.h
+++ b/src/ast/rewriter/fpa_rewriter.h
@@ -91,7 +91,6 @@ public:
     br_status mk_to_real_unspecified(unsigned ebits, unsigned sbits, expr_ref & result);
 
     br_status mk_bvwrap(expr * arg, expr_ref & result);
-    br_status mk_bvunwrap(expr * arg, expr_ref & result);
 };
 
 #endif

--- a/src/ast/rewriter/fpa_rewriter.h
+++ b/src/ast/rewriter/fpa_rewriter.h
@@ -78,7 +78,7 @@ public:
     br_status mk_to_fp(func_decl * f, unsigned num_args, expr * const * args, expr_ref & result);
     br_status mk_to_fp_unsigned(func_decl * f, expr * arg1, expr * arg2, expr_ref & result);
 
-    br_status mk_rm(expr * arg, expr_ref & result);
+    br_status mk_bv2rm(expr * arg, expr_ref & result);
     br_status mk_fp(expr * sgn, expr * exp, expr * sig, expr_ref & result);
     br_status mk_to_fp_unsigned(expr * arg1, expr * arg2, expr_ref & result);
     br_status mk_to_ubv(func_decl * f, expr * arg1, expr * arg2, expr_ref & result);

--- a/src/ast/rewriter/rewriter.cpp
+++ b/src/ast/rewriter/rewriter.cpp
@@ -173,6 +173,7 @@ void rewriter_core::elim_reflex_prs(unsigned spos) {
 rewriter_core::rewriter_core(ast_manager & m, bool proof_gen):
     m_manager(m),
     m_proof_gen(proof_gen),
+    m_cancel_check(true),
     m_result_stack(m),
     m_result_pr_stack(m),
     m_num_qvars(0) {

--- a/src/ast/rewriter/rewriter.h
+++ b/src/ast/rewriter/rewriter.h
@@ -48,6 +48,7 @@ protected:
     };
     ast_manager &              m_manager;
     bool                       m_proof_gen; 
+    bool                       m_cancel_check;
     typedef act_cache          cache;
     ptr_vector<cache>          m_cache_stack;
     cache *                    m_cache; // current cache.
@@ -114,6 +115,7 @@ public:
     ast_manager & m() const { return m_manager; }
     void reset();
     void cleanup();
+    void set_cancel_check(bool f) { m_cancel_check = f; }
 #ifdef _TRACE
     void display_stack(std::ostream & out, unsigned pp_depth);
 #endif

--- a/src/ast/rewriter/rewriter_def.h
+++ b/src/ast/rewriter/rewriter_def.h
@@ -595,7 +595,7 @@ void rewriter_tpl<Config>::set_inv_bindings(unsigned num_bindings, expr * const 
 template<typename Config>
 template<bool ProofGen>
 void rewriter_tpl<Config>::main_loop(expr * t, expr_ref & result, proof_ref & result_pr) {
-    if (m().canceled()) {
+    if (m_cancel_check && m().canceled()) {
         throw rewriter_exception(m().limit().get_cancel_msg());
     }
     SASSERT(!ProofGen || result_stack().size() == result_pr_stack().size());
@@ -629,7 +629,7 @@ template<bool ProofGen>
 void rewriter_tpl<Config>::resume_core(expr_ref & result, proof_ref & result_pr) {
     SASSERT(!frame_stack().empty());
     while (!frame_stack().empty()) {
-        if (m().canceled()) {
+        if (m_cancel_check && m().canceled()) {
             throw rewriter_exception(m().limit().get_cancel_msg());
         }
         SASSERT(!ProofGen || result_stack().size() == result_pr_stack().size());

--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -212,14 +212,11 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
 
     // auxiliary function for pull_ite_core
     expr * mk_eq_value(expr * lhs, expr * value) {
-        SASSERT(m().is_value(value));
-        if (m().is_value(lhs)) {
-            if (m().are_equal(lhs, value)) {
-                return m().mk_true();
-            }
-            else if (m().are_distinct(lhs, value)) {
-                return m().mk_false();
-            }
+        if (m().are_equal(lhs, value)) {
+            return m().mk_true();
+        }
+        else if (m().are_distinct(lhs, value)) {
+            return m().mk_false();
         }
         return m().mk_eq(lhs, value);
     }

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -277,13 +277,12 @@ bool seq_decl_plugin::is_sort_param(sort* s, unsigned& idx) {
 }
 
 bool seq_decl_plugin::match(ptr_vector<sort>& binding, sort* s, sort* sP) {
-    ast_manager& m = *m_manager;
     if (s == sP) return true;
     unsigned i;
     if (is_sort_param(sP, i)) {
         if (binding.size() <= i) binding.resize(i+1);
         if (binding[i] && (binding[i] != s)) return false;
-        TRACE("seq_verbose", tout << "setting binding @ " << i << " to " << mk_pp(s, m) << "\n";);
+        TRACE("seq_verbose", tout << "setting binding @ " << i << " to " << mk_pp(s, *m_manager) << "\n";);
         binding[i] = s;
         return true;
     }
@@ -302,7 +301,7 @@ bool seq_decl_plugin::match(ptr_vector<sort>& binding, sort* s, sort* sP) {
         return true;
     }
     else {
-        TRACE("seq", tout << "Could not match " << mk_pp(s, m) << " and " << mk_pp(sP, m) << "\n";);
+        TRACE("seq", tout << "Could not match " << mk_pp(s, *m_manager) << " and " << mk_pp(sP, *m_manager) << "\n";);
         return false;
     }
 }

--- a/src/ast/simplifier/simplifier.cpp
+++ b/src/ast/simplifier/simplifier.cpp
@@ -63,6 +63,7 @@ void simplifier::operator()(expr * s, expr_ref & r, proof_ref & p) {
     m_need_reset = true;
     reinitialize();
     expr  * s_orig = s;
+    (void)s_orig;
     expr  * old_s;
     expr  * result;
     proof * result_proof;

--- a/src/cmd_context/cmd_context_to_goal.cpp
+++ b/src/cmd_context/cmd_context_to_goal.cpp
@@ -31,8 +31,7 @@ void assert_exprs_from(cmd_context const & ctx, goal & t) {
         ptr_vector<expr>::const_iterator it   = ctx.begin_assertions();
         ptr_vector<expr>::const_iterator end  = ctx.end_assertions();
         ptr_vector<expr>::const_iterator it2  = ctx.begin_assertion_names();
-        ptr_vector<expr>::const_iterator end2 = ctx.end_assertion_names();
-        SASSERT(end - it == end2 - it2);
+        SASSERT(end - it == ctx.end_assertion_names() - it2);
         for (; it != end; ++it, ++it2) {
             t.assert_expr(*it, proofs_enabled ? m.mk_asserted(*it) : 0, m.mk_leaf(*it2));
         }

--- a/src/duality/duality_rpfp.cpp
+++ b/src/duality/duality_rpfp.cpp
@@ -2365,8 +2365,7 @@ namespace Duality {
         Term CanonIneqTerm(const Term &p){
             Term term,bound;
             Term ps = p.simplify();
-            bool ok = IsCanonIneq(ps,term,bound);
-            assert(ok);
+            VERIFY(IsCanonIneq(ps,term,bound));
             return term - bound;
         }
 

--- a/src/interp/iz3translate.cpp
+++ b/src/interp/iz3translate.cpp
@@ -342,6 +342,7 @@ public:
                     else
                         cls1.push_back(cls2[j]);
                 }
+                (void)found_pivot2;
                 assert(found_pivot2);
                 return;
             }

--- a/src/interp/iz3translate_direct.cpp
+++ b/src/interp/iz3translate_direct.cpp
@@ -362,6 +362,7 @@ public:
                     else
                         cls1.push_back(cls2[j]);
                 }
+                (void)found_pivot2;
                 assert(found_pivot2);
                 return;
             }

--- a/src/math/euclid/euclidean_solver.cpp
+++ b/src/math/euclid/euclidean_solver.cpp
@@ -580,8 +580,8 @@ struct euclidean_solver::imp {
 
     void substitute_most_recent_solution(var x) {
         SASSERT(!m_solution.empty());
-        equation & eq = *(m_solution.back());
-        TRACE("euclidean_solver", tout << "applying solution for x" << x << "\n"; display(tout, eq); tout << "\n";);
+        TRACE("euclidean_solver", tout << "applying solution for x" << x << "\n"; 
+              display(tout, *(m_solution.back())); tout << "\n";);
         occs & use_list = m_occs[x];
         occs::iterator it  = use_list.begin();
         occs::iterator end = use_list.end();

--- a/src/math/grobner/grobner.cpp
+++ b/src/math/grobner/grobner.cpp
@@ -670,7 +670,7 @@ grobner::equation * grobner::simplify(equation const * source, equation * target
             simplify(target);
         }
     }
-    while (simplified);
+    while (simplified && !m_manager.canceled());
     TRACE("grobner", tout << "result: "; display_equation(tout, *target););
     return result ? target : 0;
 }
@@ -697,7 +697,10 @@ grobner::equation * grobner::simplify_using_processed(equation * eq) {
                 simplified = true;
                 eq         = new_eq;
             }
-        }
+            if (m_manager.canceled()) {
+                return 0;
+            }
+        }        
     }
     while (simplified);
     TRACE("grobner", tout << "simplification result: "; display_equation(tout, *eq););
@@ -749,13 +752,13 @@ grobner::equation * grobner::pick_next() {
 /**
    \brief Use the given equation to simplify processed terms.
 */
-void grobner::simplify_processed(equation * eq) {
+bool grobner::simplify_processed(equation * eq) {
     ptr_buffer<equation> to_insert;
     ptr_buffer<equation> to_remove;
     ptr_buffer<equation> to_delete;
     equation_set::iterator it  = m_processed.begin();
     equation_set::iterator end = m_processed.end();
-    for (; it != end; ++it) {
+    for (; it != end && !m_manager.canceled(); ++it) {
         equation * curr        = *it;
         m_changed_leading_term = false;
         // if the leading term is simplified, then the equation has to be moved to m_to_process
@@ -795,6 +798,7 @@ void grobner::simplify_processed(equation * eq) {
     end1 = to_delete.end();
     for (; it1 != end1; ++it1)
         del_equation(*it1);
+    return !m_manager.canceled();
 }
 
 /**
@@ -944,7 +948,8 @@ bool grobner::compute_basis_step() {
         m_equations_to_unfreeze.push_back(eq);
         eq = new_eq;
     }
-    simplify_processed(eq);
+    if (m_manager.canceled()) return false;
+    if (!simplify_processed(eq)) return false;
     superpose(eq);
     m_processed.insert(eq);
     simplify_to_process(eq);
@@ -954,7 +959,7 @@ bool grobner::compute_basis_step() {
 
 bool grobner::compute_basis(unsigned threshold) {
     compute_basis_init();
-    while (m_num_new_equations < threshold) {
+    while (m_num_new_equations < threshold && !m_manager.canceled()) {
         if (compute_basis_step()) return true;
     }
     return false;

--- a/src/math/grobner/grobner.cpp
+++ b/src/math/grobner/grobner.cpp
@@ -249,6 +249,7 @@ void grobner::update_order() {
 }
 
 bool grobner::var_lt::operator()(expr * v1, expr * v2) const {
+    if (v1 == v2) return false;
     int w1 = 0;
     int w2 = 0;
     m_var2weight.find(v1, w1);
@@ -268,6 +269,8 @@ bool grobner::monomial_lt::operator()(monomial * m1, monomial * m2) const {
     for (; it1 != end1; ++it1, ++it2) {
         expr * v1 = *it1;
         expr * v2 = *it2;
+        if (v1 == v2)
+            continue;
         if (m_var_lt(v1, v2))
             return true;
         if (v1 != v2)

--- a/src/math/grobner/grobner.h
+++ b/src/math/grobner/grobner.h
@@ -175,7 +175,7 @@ protected:
 
     equation * pick_next();
 
-    void simplify_processed(equation * eq);
+    bool simplify_processed(equation * eq);
 
     void simplify_to_process(equation * eq);
 

--- a/src/math/polynomial/upolynomial.cpp
+++ b/src/math/polynomial/upolynomial.cpp
@@ -2759,6 +2759,7 @@ namespace upolynomial {
     bool manager::refine_core(unsigned sz, numeral const * p, int sign_a, mpbq_manager & bqm, mpbq & a, mpbq & b) {
         SASSERT(sign_a == eval_sign_at(sz, p, a));
         int sign_b = -sign_a;
+        (void)sign_b;
         SASSERT(sign_b == eval_sign_at(sz, p, b));
         SASSERT(sign_a == -sign_b);
         SASSERT(sign_a != 0 && sign_b != 0);
@@ -2810,9 +2811,8 @@ namespace upolynomial {
 
     bool manager::refine(unsigned sz, numeral const * p, mpbq_manager & bqm, mpbq & a, mpbq & b, unsigned prec_k) {
         int sign_a = eval_sign_at(sz, p, a);
-        int sign_b = -sign_a;
-        SASSERT(eval_sign_at(sz, p, b) == sign_b);
-        SASSERT(sign_a != 0 && sign_b != 0);
+        SASSERT(eval_sign_at(sz, p, b) == -sign_a);
+        SASSERT(sign_a != 0);
         return refine_core(sz, p, sign_a, bqm, a, b, prec_k);
     }
 
@@ -2928,6 +2928,7 @@ namespace upolynomial {
                 SASSERT(sign_a == eval_sign_at(sz, p, a));
             }
             int sign_b = -sign_a;
+            (void) sign_b;
             SASSERT(sign_b == eval_sign_at(sz, p, b));
             SASSERT(sign_a != 0 && sign_b != 0);
             if (has_zero_roots(sz, p)) {

--- a/src/math/polynomial/upolynomial_factorization.cpp
+++ b/src/math/polynomial/upolynomial_factorization.cpp
@@ -371,9 +371,10 @@ void zp_square_free_factor(zp_manager & upm, numeral_vector const & f, zp_factor
 
 bool zp_factor(zp_manager & upm, numeral_vector const & f, zp_factors & factors) {
 
-    unsigned p = get_p_from_manager(upm.m());
 
-    TRACE("polynomial::factorization", tout << "polynomial::factor("; upm.display(tout, f); tout << ") over Z_" << p << endl;);    
+    TRACE("polynomial::factorization", 
+          unsigned p = get_p_from_manager(upm.m());
+          tout << "polynomial::factor("; upm.display(tout, f); tout << ") over Z_" << p << endl;);    
 
     // get the sq-free parts (all of them will be monic)
     zp_factors sq_free_factors(upm);
@@ -435,6 +436,7 @@ bool zp_factor_square_free_berlekamp(zp_manager & upm, numeral_vector const & f,
 
     // process the null space vectors (skip first one, it's [1, 0, ..., 0]) while generating the factors
     unsigned d = upm.degree(f);
+    (void)d;
     scoped_numeral_vector v_k(zpm);
     while (Q_I.next_null_space_vector(v_k)) {
 

--- a/src/math/simplex/model_based_opt.cpp
+++ b/src/math/simplex/model_based_opt.cpp
@@ -34,8 +34,7 @@ std::ostream& operator<<(std::ostream& out, opt::ineq_type ie) {
 namespace opt {
     
 
-    model_based_opt::model_based_opt():
-        m_objective_id(0)
+    model_based_opt::model_based_opt()
     {
         m_rows.push_back(row());
     }
@@ -446,6 +445,133 @@ namespace opt {
 
     void model_based_opt::set_objective(vector<var> const& coeffs, rational const& c) {
         set_row(m_objective_id, coeffs, c, t_le);
+    }
+
+    void model_based_opt::get_live_rows(vector<row>& rows) {
+        for (unsigned i = 0; i < m_rows.size(); ++i) {
+            if (m_rows[i].m_alive) {
+                rows.push_back(m_rows[i]);
+            }
+        }
+    }
+
+    //
+    // pick glb and lub representative.
+    // The representative is picked such that it 
+    // represents the fewest inequalities. 
+    // The constraints that enforce a glb or lub are not forced.
+    // The constraints that separate the glb from ub or the lub from lb
+    // are not forced.
+    // In other words, suppose there are 
+    // . N inequalities of the form t <= x
+    // . M inequalities of the form s >= x
+    // . t0 is glb among N under valuation.
+    // . s0 is lub among M under valuation.
+    // If N < M
+    //    create the inequalities:
+    //       t <= t0 for each t other than t0 (N-1 inequalities).
+    //       t0 <= s for each s (M inequalities).
+    // If N >= M the construction is symmetric.
+    // 
+    void model_based_opt::project(unsigned x) {
+        unsigned_vector& lub_rows = m_lub;
+        unsigned_vector& glb_rows = m_glb;        
+        unsigned lub_index = UINT_MAX, glb_index = UINT_MAX;
+        bool     lub_strict = false, glb_strict = false;
+        rational lub_val, glb_val;
+        rational const& x_val = m_var2value[x];
+        unsigned_vector const& row_ids = m_var2row_ids[x];
+        uint_set visited;
+        lub_rows.reset();
+        glb_rows.reset();
+        // select the lub and glb.
+        for (unsigned i = 0; i < row_ids.size(); ++i) {
+            unsigned row_id = row_ids[i];
+            if (visited.contains(row_id)) {
+                continue;
+            }
+            visited.insert(row_id);
+            row& r = m_rows[row_id];
+            if (!r.m_alive) {
+                continue;
+            }
+            rational a = get_coefficient(row_id, x);
+            if (a.is_zero()) {
+                continue;
+            }
+            if (r.m_type == t_eq) {
+                solve_for(row_id, x);
+                return;
+            }
+            if (a.is_pos()) {
+                rational lub_value = x_val - (r.m_value/a);
+                if (lub_rows.empty() || 
+                    lub_value < lub_val ||
+                    (lub_value == lub_val && r.m_type == t_lt && !lub_strict)) {
+                    lub_val = lub_value;
+                    lub_index = row_id;
+                    lub_strict = r.m_type == t_lt;                    
+                }
+                lub_rows.push_back(row_id);
+            }
+            else {
+                SASSERT(a.is_neg());
+                rational glb_value = x_val - (r.m_value/a);
+                if (glb_rows.empty() || 
+                    glb_value > glb_val ||
+                    (glb_value == glb_val && r.m_type == t_lt && !glb_strict)) {
+                    glb_val = glb_value;
+                    glb_index = row_id;
+                    glb_strict = r.m_type == t_lt;                    
+                }
+                glb_rows.push_back(row_id);
+            }
+        }
+        unsigned row_index = (lub_rows.size() <= glb_rows.size())? lub_index : glb_index;
+        glb_rows.append(lub_rows);            
+        if (row_index == UINT_MAX) {
+            for (unsigned i = 0; i < glb_rows.size(); ++i) {
+                unsigned row_id = glb_rows[i];
+                SASSERT(m_rows[row_id].m_alive);
+                SASSERT(!get_coefficient(row_id, x).is_zero());
+                m_rows[row_id].m_alive = false;
+            }
+        }
+        else {
+            rational coeff = get_coefficient(row_index, x);
+            for (unsigned i = 0; i < glb_rows.size(); ++i) {
+                unsigned row_id = glb_rows[i];
+                if (row_id != row_index) {
+                    resolve(row_index, coeff, row_id, x);
+                }
+            }
+            m_rows[row_index].m_alive = false;
+        }
+    }
+
+    void model_based_opt::solve_for(unsigned row_id1, unsigned x) {
+        rational a = get_coefficient(row_id1, x);
+        row& r1 = m_rows[row_id1];
+        SASSERT(!a.is_zero());
+        SASSERT(r1.m_type == t_eq);
+        SASSERT(r1.m_alive);
+        unsigned_vector const& row_ids = m_var2row_ids[x];
+        uint_set visited;
+        visited.insert(row_id1);
+        for (unsigned i = 0; i < row_ids.size(); ++i) {
+            unsigned row_id2 = row_ids[i];
+            if (!visited.contains(row_id2)) {                
+                visited.insert(row_id2);
+                resolve(row_id1, a, row_id2, x);            
+            }
+        }
+        r1.m_alive = false;
+    }
+
+    void model_based_opt::project(unsigned num_vars, unsigned const* vars) {
+        for (unsigned i = 0; i < num_vars; ++i) {
+            project(vars[i]);
+        }
     }
 
 }

--- a/src/math/simplex/model_based_opt.h
+++ b/src/math/simplex/model_based_opt.h
@@ -48,7 +48,6 @@ namespace opt {
                 }
             };
         };
-    private:
         struct row {
             row(): m_type(t_le), m_value(0), m_alive(false) {}
             vector<var> m_vars;         // variables with coefficients
@@ -58,11 +57,14 @@ namespace opt {
             bool        m_alive;        // rows can be marked dead if they have been processed.
         };
 
+    private:
+
         vector<row>             m_rows;
-        unsigned                m_objective_id;
+        static const unsigned   m_objective_id = 0;
         vector<unsigned_vector> m_var2row_ids;
         vector<rational>        m_var2value;
         vector<var>             m_new_vars;
+        unsigned_vector         m_lub, m_glb;
         
         bool invariant();
         bool invariant(unsigned index, row const& r);
@@ -80,6 +82,10 @@ namespace opt {
         void set_row(unsigned row_id, vector<var> const& coeffs, rational const& c, ineq_type rel);
         
         void update_values(unsigned_vector const& bound_vars, unsigned_vector const& bound_trail);
+
+        void project(unsigned var);
+
+        void solve_for(unsigned row_id, unsigned x);
 
     public:
 
@@ -105,6 +111,17 @@ namespace opt {
         // optimal.
         //
         inf_eps maximize();
+
+
+        // 
+        // Project set of variables from inequalities.
+        //
+        void project(unsigned num_vars, unsigned const* vars);
+
+        //
+        // Extract current rows (after projection).
+        // 
+        void get_live_rows(vector<row>& rows);
 
         void display(std::ostream& out) const;
         void display(std::ostream& out, row const& r) const;

--- a/src/math/simplex/simplex_def.h
+++ b/src/math/simplex/simplex_def.h
@@ -998,6 +998,7 @@ namespace simplex {
     template<typename Ext>
     bool simplex<Ext>::well_formed_row(row const& r) const {
         var_t s = m_row2base[r.id()];
+        (void)s;
         SASSERT(m_vars[s].m_base2row == r.id());
         SASSERT(m_vars[s].m_is_base);
         // SASSERT(m.is_neg(m_vars[s].m_base_coeff));

--- a/src/math/simplex/sparse_matrix_def.h
+++ b/src/math/simplex/sparse_matrix_def.h
@@ -542,10 +542,11 @@ namespace simplex {
                 continue;
             }
             SASSERT(!rows.contains(c.m_row_id));
-            _row const& row = m_rows[c.m_row_id];
-            _row_entry const& r = row.m_entries[c.m_row_idx];
-            SASSERT(r.m_var == v); 
-            SASSERT((unsigned)r.m_col_idx == i);
+            DEBUG_CODE(
+                _row const& row = m_rows[c.m_row_id];
+                _row_entry const& r = row.m_entries[c.m_row_idx];
+                SASSERT(r.m_var == v); 
+                SASSERT((unsigned)r.m_col_idx == i););
             rows.insert(c.m_row_id);
         }                           
         int idx = col.m_first_free_idx;

--- a/src/math/simplex/sparse_matrix_def.h
+++ b/src/math/simplex/sparse_matrix_def.h
@@ -509,12 +509,13 @@ namespace simplex {
                 dead.insert(i);
                 continue;
             }
-            SASSERT(!vars.contains(e.m_var));
-            SASSERT(!m.is_zero(e.m_coeff));            
-            SASSERT(e.m_var != dead_id);
-            col_entry const& c = m_columns[e.m_var].m_entries[e.m_col_idx];
-            SASSERT((unsigned)c.m_row_id == row_id);
-            SASSERT((unsigned)c.m_row_idx == i);
+            DEBUG_CODE(
+                SASSERT(!vars.contains(e.m_var));
+                SASSERT(!m.is_zero(e.m_coeff));            
+                SASSERT(e.m_var != dead_id);
+                col_entry const& c = m_columns[e.m_var].m_entries[e.m_col_idx];
+                SASSERT((unsigned)c.m_row_id == row_id);
+                SASSERT((unsigned)c.m_row_idx == i););
             vars.insert(e.m_var);
         }                  
         int idx = r.m_first_free_idx;

--- a/src/model/model_evaluator.cpp
+++ b/src/model/model_evaluator.cpp
@@ -365,6 +365,7 @@ struct model_evaluator::imp : public rewriter_tpl<evaluator_cfg> {
                                     false, // no proofs for evaluator
                                     m_cfg),
         m_cfg(md.get_manager(), md, p) {
+        set_cancel_check(false);
     }
 };
 

--- a/src/model/model_evaluator.cpp
+++ b/src/model/model_evaluator.cpp
@@ -114,7 +114,8 @@ struct evaluator_cfg : public default_rewriter_cfg {
     br_status reduce_app(func_decl * f, unsigned num, expr * const * args, expr_ref & result, proof_ref & result_pr) {
         result_pr = 0;
         family_id fid = f->get_family_id();
-        if (num == 0 && (fid == null_family_id || m().get_plugin(f->get_family_id())->is_considered_uninterpreted(f))) {
+        bool is_uninterp = fid != null_family_id && m().get_plugin(fid)->is_considered_uninterpreted(f);
+        if (num == 0 && (fid == null_family_id || is_uninterp)) {
             expr * val = m_model.get_const_interp(f);
             if (val != 0) {
                 result = val;

--- a/src/model/model_evaluator.cpp
+++ b/src/model/model_evaluator.cpp
@@ -150,7 +150,7 @@ struct evaluator_cfg : public default_rewriter_cfg {
                     st = m_f_rw.mk_eq_core(args[0], args[1], result);
                 else if (s_fid == m_seq_rw.get_fid())
                     st = m_seq_rw.mk_eq_core(args[0], args[1], result);
-                else if (fid == m_ar_rw.get_fid())
+                else if (s_fid == m_ar_rw.get_fid())
                     st = mk_array_eq(args[0], args[1], result);
                 if (st != BR_FAILED)
                     return st;

--- a/src/model/model_evaluator.cpp
+++ b/src/model/model_evaluator.cpp
@@ -259,6 +259,8 @@ struct evaluator_cfg : public default_rewriter_cfg {
 
 
     br_status mk_array_eq(expr* a, expr* b, expr_ref& result) {
+        return BR_FAILED;
+        // disabled until made more efficient
         if (a == b) {
             result = m().mk_true();
             return BR_DONE;
@@ -271,6 +273,7 @@ struct evaluator_cfg : public default_rewriter_cfg {
             conj.push_back(m().mk_eq(else1, else2));
             args1.push_back(a);
             args2.push_back(b);
+            // TBD: this is too inefficient.
             for (unsigned i = 0; i < stores.size(); ++i) {
                 args1.resize(1); args1.append(stores[i].size() - 1, stores[i].c_ptr());
                 args2.resize(1); args2.append(stores[i].size() - 1, stores[i].c_ptr());

--- a/src/muz/base/dl_context.cpp
+++ b/src/muz/base/dl_context.cpp
@@ -188,9 +188,8 @@ namespace datalog {
         if (m_trail.get_num_scopes() == 0) {
             throw default_exception("there are no backtracking points to pop to");
         }
-        if(m_engine.get()){
-            if(get_engine() != DUALITY_ENGINE)
-            throw default_exception("operation is not supported by engine");
+        if (m_engine.get() && get_engine() != DUALITY_ENGINE) {
+            throw default_exception("pop operation is only supported by duality engine");
         }
         m_trail.pop_scope(1); 
     }

--- a/src/muz/fp/dl_cmds.cpp
+++ b/src/muz/fp/dl_cmds.cpp
@@ -229,6 +229,7 @@ public:
     }
 
     virtual void prepare(cmd_context & ctx) { 
+        ctx.m(); // ensure manager is initialized.
         parametric_cmd::prepare(ctx);
         m_target   = 0; 
     }
@@ -390,6 +391,7 @@ public:
     virtual unsigned get_arity() const { return VAR_ARITY; }
 
     virtual void prepare(cmd_context & ctx) {
+        ctx.m(); // ensure manager is initialized.
         m_arg_idx = 0; 
         m_query_arg_idx = 0; 
         m_domain = 0;
@@ -450,6 +452,7 @@ public:
     virtual unsigned get_arity() const { return 2; }
 
     virtual void prepare(cmd_context & ctx) {
+        ctx.m(); // ensure manager is initialized.
         m_arg_idx = 0; 
     }
     virtual cmd_arg_kind next_arg_kind(cmd_context & ctx) const { 

--- a/src/muz/fp/dl_cmds.cpp
+++ b/src/muz/fp/dl_cmds.cpp
@@ -300,6 +300,7 @@ public:
                 break;
 
             case datalog::OK: 
+                (void)query_exn;
                 SASSERT(query_exn);
                 break;
 

--- a/src/muz/fp/dl_cmds.cpp
+++ b/src/muz/fp/dl_cmds.cpp
@@ -219,6 +219,13 @@ public:
 
     virtual void set_next_arg(cmd_context & ctx, func_decl* t) {
         m_target = t;
+        if (t->get_family_id() != null_family_id) {
+            throw cmd_exception("Invalid query argument, expected uinterpreted function name, but argument is interpreted");
+        }
+        datalog::context& dlctx = m_dl_ctx->dlctx();
+        if (!dlctx.get_predicates().contains(t)) {
+            throw cmd_exception("Invalid query argument, expected a predicate registered as a relation");
+        }
     }
 
     virtual void prepare(cmd_context & ctx) { 

--- a/src/muz/pdr/pdr_farkas_learner.cpp
+++ b/src/muz/pdr/pdr_farkas_learner.cpp
@@ -923,6 +923,7 @@ namespace pdr {
             if (p->get_decl_kind() == PR_ASSERTED &&
                 bs.contains(m.get_fact(p))) {
                 expr* fact = m.get_fact(p);
+                (void)p0;
                 TRACE("farkas_learner", 
                       tout << mk_ll_pp(p0,m) << "\n";
                       tout << "Add: " << mk_pp(p,m) << "\n";);

--- a/src/muz/rel/dl_external_relation.cpp
+++ b/src/muz/rel/dl_external_relation.cpp
@@ -338,9 +338,8 @@ namespace datalog {
             : m_plugin(p),
               m_condition(condition, p.get_ast_manager()),
               m_filter_fn(p.get_ast_manager()) {
-            ast_manager& m = p.get_ast_manager();
             p.mk_filter_fn(relation_sort, condition, m_filter_fn);
-            SASSERT(m.is_bool(condition));
+            SASSERT(p.get_ast_manager().is_bool(condition));
         }
 
         virtual void operator()(relation_base & r) {

--- a/src/muz/rel/dl_finite_product_relation.cpp
+++ b/src/muz/rel/dl_finite_product_relation.cpp
@@ -1566,13 +1566,12 @@ namespace datalog {
                 return;
             }
 
-            finite_product_relation_plugin & plugin = r.get_plugin();
-            if(!m_neg_intersection_join) {
-            }
             scoped_rel<finite_product_relation> intersection = get((*m_neg_intersection_join)(r, neg));
-            SASSERT(&intersection->get_plugin()==&plugin); //the result of join is also finite product
-            SASSERT(r.get_signature()==intersection->get_signature());
 
+            DEBUG_CODE(
+                finite_product_relation_plugin & plugin = r.get_plugin();
+                SASSERT(&intersection->get_plugin()==&plugin); //the result of join is also finite product
+                SASSERT(r.get_signature()==intersection->get_signature()););
             table_base & r_table = r.get_table();
             table_plugin & tplugin = r_table.get_plugin();
             relation_manager & rmgr = r.get_manager();

--- a/src/muz/rel/karr_relation.cpp
+++ b/src/muz/rel/karr_relation.cpp
@@ -173,6 +173,7 @@ namespace datalog {
                 else {
                     processed = false;
                 }
+                (void)processed;
                 TRACE("dl", tout << (processed?"+ ":"- ") << mk_pp(e, m) << "\n";
                       if (processed) matrix::display_ineq(tout, row, M.b.back(), M.eq.back());
                       );

--- a/src/muz/rel/udoc_relation.cpp
+++ b/src/muz/rel/udoc_relation.cpp
@@ -404,7 +404,7 @@ namespace datalog {
         rename_fn(udoc_relation const& t, unsigned cycle_len, const unsigned * cycle) 
             : convenient_relation_rename_fn(t.get_signature(), cycle_len, cycle) {
             udoc_plugin& p = t.get_plugin();
-            ast_manager& m = p.get_ast_manager();
+            
             relation_signature const& sig1 = t.get_signature();
             relation_signature const& sig2 = get_result_signature();
             unsigned_vector permutation0, column_info;
@@ -429,6 +429,7 @@ namespace datalog {
             SASSERT(column == t.get_num_bits());
 
             TRACE("doc",
+                  ast_manager& m = p.get_ast_manager();
                   sig1.output(m, tout << "sig1: "); tout << "\n";
                   sig2.output(m, tout << "sig2: "); tout << "\n";
                   tout << "permute: ";

--- a/src/muz/transforms/dl_mk_bit_blast.cpp
+++ b/src/muz/transforms/dl_mk_bit_blast.cpp
@@ -70,13 +70,12 @@ namespace datalog {
                 func_interp* f = model->get_func_interp(p);
                 if (!f) continue;
                 expr_ref body(m);                
-                unsigned arity_p = p->get_arity();
                 unsigned arity_q = q->get_arity();
                 TRACE("dl",
                       model_v2_pp(tout, *model);
                       tout << mk_pp(p, m) << "\n";
                       tout << mk_pp(q, m) << "\n";);
-                SASSERT(0 < arity_p);
+                SASSERT(0 < p->get_arity());
                 SASSERT(f);
                 model->register_decl(p, f->copy());
                 func_interp* g = alloc(func_interp, m, arity_q);

--- a/src/muz/transforms/dl_mk_quantifier_abstraction.cpp
+++ b/src/muz/transforms/dl_mk_quantifier_abstraction.cpp
@@ -97,7 +97,7 @@ namespace datalog {
 
                 TRACE("dl", tout << mk_pp(body, m) << "\n";);
                 // 2. replace bound variables by constants.
-                expr_ref_vector consts(m), bound(m), free(m);
+                expr_ref_vector consts(m), bound(m), _free(m);
                 svector<symbol> names;
                 ptr_vector<sort> bound_sorts;
                 for (unsigned i = 0; i < sorts.size(); ++i) {
@@ -110,7 +110,7 @@ namespace datalog {
                         bound_sorts.push_back(s);
                     }
                     else {
-                        free.push_back(consts.back());
+                        _free.push_back(consts.back());
                     }
                 }
                 rep(body);                
@@ -123,8 +123,8 @@ namespace datalog {
 
                 TRACE("dl", tout << mk_pp(body, m) << "\n";);
                 // 4. replace remaining constants by variables.                                
-                for (unsigned i = 0; i < free.size(); ++i) {
-                    rep.insert(free[i].get(), m.mk_var(i, m.get_sort(free[i].get())));
+                for (unsigned i = 0; i < _free.size(); ++i) {
+                    rep.insert(_free[i].get(), m.mk_var(i, m.get_sort(_free[i].get())));
                 }
                 rep(body);                
                 g->set_else(body);

--- a/src/muz/transforms/dl_mk_quantifier_abstraction.cpp
+++ b/src/muz/transforms/dl_mk_quantifier_abstraction.cpp
@@ -71,9 +71,8 @@ namespace datalog {
                 svector<bool> const& is_bound  = m_bound[i];
                 func_interp* f = old_model->get_func_interp(p);
                 expr_ref body(m);                
-                unsigned arity_p = p->get_arity();
                 unsigned arity_q = q->get_arity();
-                SASSERT(0 < arity_p);
+                SASSERT(0 < p->get_arity());
                 func_interp* g = alloc(func_interp, m, arity_q);
 
                 if (f) {

--- a/src/nlsat/nlsat_explain.cpp
+++ b/src/nlsat/nlsat_explain.cpp
@@ -1165,8 +1165,7 @@ namespace nlsat {
                 if (max_var(new_lit) < max) {
                     // The conflicting core may have redundant literals.
                     // We should check whether new_lit is true in the current model, and discard it if that is the case
-                    lbool val = m_solver.value(new_lit);
-                    SASSERT(val != l_undef);
+                    VERIFY(m_solver.value(new_lit) != l_undef);
                     if (m_solver.value(new_lit) == l_false)
                         add_literal(new_lit);
                     new_lit = true_literal;

--- a/src/nlsat/nlsat_interval_set.cpp
+++ b/src/nlsat/nlsat_interval_set.cpp
@@ -102,14 +102,14 @@ namespace nlsat {
     
     // Check if the intervals are valid, ordered, and are disjoint.
     bool check_interval_set(anum_manager & am, unsigned sz, interval const * ints) {
-        for (unsigned i = 0; i < sz; i++) {
-            interval const & curr = ints[i];
-            SASSERT(check_interval(am, curr));
-            if (i < sz - 1) {
-                interval const & next = ints[i+1];
-                SASSERT(check_no_overlap(am, curr, next));
-            }
-        }
+        DEBUG_CODE(
+            for (unsigned i = 0; i < sz; i++) {
+                interval const & curr = ints[i];
+                SASSERT(check_interval(am, curr));
+                if (i < sz - 1) {
+                    SASSERT(check_no_overlap(am, curr, ints[i+1]));
+                }
+            });
         return true;
     }
 

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -1728,27 +1728,28 @@ namespace nlsat {
         // -----------------------
         
         bool check_watches() const {
-            for (var x = 0; x < num_vars(); x++) {
-                clause_vector const & cs = m_watches[x];
-                unsigned sz = cs.size();
-                for (unsigned i = 0; i < sz; i++) {
-                    clause const & c = *(cs[i]);
-                    SASSERT(max_var(c) == x);
-                }
-            }
+            DEBUG_CODE(
+                for (var x = 0; x < num_vars(); x++) {
+                    clause_vector const & cs = m_watches[x];
+                    unsigned sz = cs.size();
+                    for (unsigned i = 0; i < sz; i++) {
+                        SASSERT(max_var(*(cs[i])) == x);
+                    }
+                });
             return true;
         }
 
         bool check_bwatches() const {
-            for (bool_var b = 0; b < m_bwatches.size(); b++) {
-                clause_vector const & cs = m_bwatches[b];
-                unsigned sz = cs.size();
-                for (unsigned i = 0; i < sz; i++) {
-                    clause const & c = *(cs[i]);
-                    SASSERT(max_var(c) == null_var);
-                    SASSERT(max_bvar(c) == b);
-                }
-            }
+            DEBUG_CODE(
+                for (bool_var b = 0; b < m_bwatches.size(); b++) {
+                    clause_vector const & cs = m_bwatches[b];
+                    unsigned sz = cs.size();
+                    for (unsigned i = 0; i < sz; i++) {
+                        clause const & c = *(cs[i]);
+                        SASSERT(max_var(c) == null_var);
+                        SASSERT(max_bvar(c) == b);
+                    }
+                });
             return true;
         }
 

--- a/src/opt/hitting_sets.cpp
+++ b/src/opt/hitting_sets.cpp
@@ -762,6 +762,7 @@ namespace opt {
         }
 
         bool invariant() {
+            DEBUG_CODE(
             for (unsigned i = 0; i < m_fwatch.size(); ++i) {
                 for (unsigned j = 0; j < m_fwatch[i].size(); ++j) {
                     set const& S = *m_F[m_fwatch[i][j]];
@@ -773,7 +774,7 @@ namespace opt {
                     set const& S = *m_T[m_twatch[i][j]];
                     SASSERT(S[0] == i || S[1] == i);
                 }
-            }
+            });
             return true;
         }
 

--- a/src/opt/opt_cmds.cpp
+++ b/src/opt/opt_cmds.cpp
@@ -141,6 +141,13 @@ class alternate_min_max_cmd : public cmd {
     app_ref_vector*      m_vars;
     svector<bool>        m_is_max;
     unsigned             m_position;
+
+    app_ref_vector& vars(cmd_context& ctx) {
+        if (!m_vars) {
+            m_vars = alloc(app_ref_vector, ctx.m());
+        }
+        return *m_vars;
+    }
 public:
     alternate_min_max_cmd():
         cmd("min-max"),
@@ -150,6 +157,7 @@ public:
     
     virtual void reset(cmd_context & ctx) { 
         dealloc(m_vars);
+        m_vars = 0;
         m_is_max.reset();
         m_position = 0;
     }
@@ -176,8 +184,7 @@ public:
             }
             else {
                 m_is_max.push_back(is_max);
-                if (!m_vars) m_vars = alloc(app_ref_vector, ctx.m());
-                m_vars->push_back(ctx.m().mk_const(ctx.find_func_decl(slist[i])));
+                vars(ctx).push_back(ctx.m().mk_const(ctx.find_func_decl(slist[i])));
             }
         }
         ++m_position;
@@ -188,8 +195,8 @@ public:
             throw cmd_exception("malformed objective term: it cannot be a quantifier or bound variable");
         }
         ++m_position;
-        if (!m_vars) m_vars = alloc(app_ref_vector, ctx.m());
-        get_opt(ctx).min_max(to_app(t), *m_vars, m_is_max);
+        get_opt(ctx).min_max(to_app(t), vars(ctx), m_is_max);
+        reset(ctx);
     }
 
     virtual void failure_cleanup(cmd_context & ctx) {

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -218,11 +218,9 @@ namespace opt {
         import_scoped_state(); 
         normalize();
         internalize();
-        update_solver();
-        solver& s = get_solver();
-        s.assert_expr(m_hard_constraints);
-        std::cout << "min-max is TBD\n";
-        return l_undef;
+        qe::max_min_opt max_min(m, m_params);
+        max_min.add(m_hard_constraints);
+        return max_min.check(is_max, vars, t);
     }
 
 

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -212,18 +212,6 @@ namespace opt {
         m_hard_constraints.append(s.m_hard);
     }
 
-    lbool context::min_max(app* t, app_ref_vector const& vars, svector<bool> const& is_max) {
-        clear_state();
-        init_solver(); 
-        import_scoped_state(); 
-        normalize();
-        internalize();
-        qe::max_min_opt max_min(m, m_params);
-        max_min.add(m_hard_constraints);
-        return max_min.check(is_max, vars, t);
-    }
-
-
     lbool context::optimize() {
         if (m_pareto) {
             return execute_pareto();
@@ -236,12 +224,12 @@ namespace opt {
         import_scoped_state(); 
         normalize();
         internalize();
+        update_solver();
 #if 0
         if (is_qsat_opt()) {
             return run_qsat_opt();
         }
 #endif
-        update_solver();
         solver& s = get_solver();
         s.assert_expr(m_hard_constraints);
         display_benchmark();
@@ -1473,6 +1461,7 @@ namespace opt {
             value.neg();
         }
         if (result != l_undef) {
+            m_optsmt.setup(*m_opt_solver.get());
             m_optsmt.update_lower(obj.m_index, value);
             m_optsmt.update_upper(obj.m_index, value);
         }

--- a/src/opt/opt_context.h
+++ b/src/opt/opt_context.h
@@ -28,7 +28,7 @@ Notes:
 #include "arith_decl_plugin.h"
 #include "bv_decl_plugin.h"
 #include "cmd_context.h"
-
+#include "qsat.h"
 
 namespace opt {
 
@@ -145,6 +145,7 @@ namespace opt {
         ref<solver>         m_solver;
         ref<solver>         m_sat_solver;
         scoped_ptr<pareto_base>          m_pareto;
+        scoped_ptr<qe::qmax> m_qmax;
         sref_vector<model>  m_box_models;
         unsigned            m_box_index;
         params_ref          m_params;

--- a/src/opt/opt_context.h
+++ b/src/opt/opt_context.h
@@ -172,7 +172,6 @@ namespace opt {
         virtual ~context();
         unsigned add_soft_constraint(expr* f, rational const& w, symbol const& id);
         unsigned add_objective(app* t, bool is_max);
-        lbool min_max(app* t, app_ref_vector const& vars, svector<bool> const& is_max);
         void add_hard_constraint(expr* f);
         
 

--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -344,6 +344,10 @@ namespace opt {
     }
     
     expr_ref opt_solver::mk_ge(unsigned var, inf_eps const& val) {
+		if (!val.is_finite())
+		{
+			return expr_ref(val.is_pos() ? m.mk_false() : m.mk_true(), m);
+		}
         smt::theory_opt& opt = get_optimizer();
         smt::theory_var v = m_objective_vars[var];
 

--- a/src/opt/optsmt.cpp
+++ b/src/opt/optsmt.cpp
@@ -34,6 +34,7 @@ Notes:
 #include "arith_decl_plugin.h"
 #include "theory_arith.h"
 #include "ast_pp.h"
+#include "ast_util.h"
 #include "model_pp.h"
 #include "th_rewriter.h"
 #include "opt_params.hpp"
@@ -96,6 +97,158 @@ namespace opt {
     /*
         Enumerate locally optimal assignments until fixedpoint.
     */
+    lbool optsmt::geometric_opt() {
+        lbool is_sat = l_true;
+
+        expr_ref bound(m);
+
+        vector<inf_eps> lower(m_lower);
+        unsigned steps = 0;
+        unsigned step_incs = 0;
+        rational delta_per_step(1);
+        unsigned num_scopes = 0;
+        unsigned delta_index = 0;    // index of objective to speed up.
+
+        while (!m.canceled()) {
+            SASSERT(delta_per_step.is_int());
+            SASSERT(delta_per_step.is_pos());
+            is_sat = m_s->check_sat(0, 0);
+            if (is_sat == l_true) {                
+                bound = update_lower();
+                if (!get_max_delta(lower, delta_index)) {
+                    delta_per_step = rational::one();
+                }
+                else if (steps > step_incs) {
+                    delta_per_step *= rational(2);
+                    ++step_incs;
+                    steps = 0;
+                }
+                else {
+                    ++steps;
+                }
+                if (delta_per_step > rational::one()) {
+                    m_s->push();
+                    ++num_scopes;
+                    // only try to improve delta_index. 
+                    bound = m_s->mk_ge(delta_index, m_lower[delta_index] + inf_eps(delta_per_step));
+                }
+                TRACE("opt", tout << delta_per_step << " " << bound << "\n";);
+                m_s->assert_expr(bound);
+            }
+            else if (is_sat == l_false && delta_per_step > rational::one()) {
+                steps = 0;
+                step_incs = 0;
+                delta_per_step = rational::one();
+                SASSERT(num_scopes > 0);
+                --num_scopes;
+                m_s->pop(1);             
+            }
+            else {
+                break;
+            }
+        }
+        m_s->pop(num_scopes);        
+        
+        if (m.canceled() || is_sat == l_undef) {
+            return l_undef;
+        }
+
+        // set the solution tight.
+        for (unsigned i = 0; i < m_lower.size(); ++i) {
+            m_upper[i] = m_lower[i];
+        }
+        
+        return l_true;        
+    }
+
+
+    lbool optsmt::geometric_lex(unsigned obj_index, bool is_maximize) {
+        arith_util arith(m);
+        bool is_int = arith.is_int(m_objs[obj_index].get());
+        lbool is_sat = l_true;
+        expr_ref bound(m);
+
+        for (unsigned i = 0; i < obj_index; ++i) {
+            commit_assignment(i);
+        }
+
+        unsigned steps = 0;
+        unsigned step_incs = 0;
+        rational delta_per_step(1);
+        unsigned num_scopes = 0;
+
+        while (!m.canceled()) {
+            SASSERT(delta_per_step.is_int());
+            SASSERT(delta_per_step.is_pos());
+            is_sat = m_s->check_sat(0, 0);
+            if (is_sat == l_true) {                
+                m_s->maximize_objective(obj_index, bound);
+                m_s->get_model(m_model);
+                m_s->get_labels(m_labels);
+                inf_eps obj = m_s->saved_objective_value(obj_index);
+                update_lower_lex(obj_index, obj, is_maximize);
+                if (!is_int || !m_lower[obj_index].is_finite()) {
+                    delta_per_step = rational(1);
+                }
+                else if (steps > step_incs) {
+                    delta_per_step *= rational(2);
+                    ++step_incs;
+                    steps = 0;
+                }
+                else {
+                    ++steps;
+                }
+                if (delta_per_step > rational::one()) {
+                    m_s->push();
+                    ++num_scopes;
+                    bound = m_s->mk_ge(obj_index, obj + inf_eps(delta_per_step));
+                }
+                TRACE("opt", tout << delta_per_step << " " << bound << "\n";);
+                m_s->assert_expr(bound);
+            }
+            else if (is_sat == l_false && delta_per_step > rational::one()) {
+                steps = 0;
+                step_incs = 0;
+                delta_per_step = rational::one();
+                SASSERT(num_scopes > 0);
+                --num_scopes;
+                m_s->pop(1);             
+            }
+            else {
+                break;
+            }
+        }
+        m_s->pop(num_scopes);        
+        
+        if (m.canceled() || is_sat == l_undef) {
+            return l_undef;
+        }
+
+        // set the solution tight.
+        m_upper[obj_index] = m_lower[obj_index];    
+        for (unsigned i = obj_index+1; i < m_lower.size(); ++i) {
+            m_lower[i] = inf_eps(rational(-1), inf_rational(0));
+        }
+        return l_true;
+    }
+
+    bool optsmt::get_max_delta(vector<inf_eps> const& lower, unsigned& idx) {
+        arith_util arith(m);
+        inf_eps max_delta;
+        for (unsigned i = 0; i < m_lower.size(); ++i) {
+            if (arith.is_int(m_objs[i].get())) {
+                inf_eps delta = m_lower[i] - lower[i];  
+                if (m_lower[i].is_finite() && delta > max_delta) {
+                    max_delta = delta;
+                }
+            }
+        }
+        return max_delta.is_pos();
+    }
+
+    /*
+        Enumerate locally optimal assignments until fixedpoint.
+    */
     lbool optsmt::farkas_opt() {
         smt::theory_opt& opt = m_s->get_optimizer();
 
@@ -122,6 +275,7 @@ namespace opt {
     }
 
     lbool optsmt::symba_opt() {
+
         smt::theory_opt& opt = m_s->get_optimizer();
 
         if (typeid(smt::theory_inf_arith) != typeid(opt)) {
@@ -138,7 +292,7 @@ namespace opt {
             }
             
             
-            fml = m.mk_or(ors.size(), ors.c_ptr());
+            fml = mk_or(ors);
             tmp = m.mk_fresh_const("b", m.mk_bool_sort());
             fml = m.mk_implies(tmp, fml);
             vars[0] = tmp;
@@ -163,7 +317,7 @@ namespace opt {
                         }
                     }
                     set_max(m_lower, m_s->get_objective_values(), disj);
-                    fml = m.mk_or(ors.size(), ors.c_ptr());
+                    fml = mk_or(ors);
                     tmp = m.mk_fresh_const("b", m.mk_bool_sort());
                     fml = m.mk_implies(tmp, fml);
                     vars[0] = tmp;
@@ -176,13 +330,30 @@ namespace opt {
                 }
             }
         }
-        bound = m.mk_or(m_lower_fmls.size(), m_lower_fmls.c_ptr());
+        bound = mk_or(m_lower_fmls);
         m_s->assert_expr(bound);
         
         if (m.canceled()) {
             return l_undef;
         }
-        return basic_opt();
+        return geometric_opt();
+    }
+
+    void optsmt::update_lower_lex(unsigned idx, inf_eps const& v, bool is_maximize) {
+        if (v > m_lower[idx]) {
+            m_lower[idx] = v;                
+            IF_VERBOSE(1, 
+                       if (is_maximize) 
+                           verbose_stream() << "(optsmt lower bound: " << v << ")\n";
+                       else
+                           verbose_stream() << "(optsmt upper bound: " << (-v) << ")\n";
+                       );
+            expr_ref tmp(m);
+            for (unsigned i = idx+1; i < m_vars.size(); ++i) {
+                m_s->maximize_objective(i, tmp);
+                m_lower[i] = m_s->saved_objective_value(i);
+            }
+        }
     }
 
     void optsmt::update_lower(unsigned idx, inf_eps const& v) {
@@ -196,28 +367,22 @@ namespace opt {
         m_upper[idx] = v;                    
     }
 
+    std::ostream& operator<<(std::ostream& out, vector<inf_eps> const& vs) {
+        for (unsigned i = 0; i < vs.size(); ++i) {
+            out << vs[i] << " ";
+        }
+        return out;
+    }
+
     expr_ref optsmt::update_lower() {
         expr_ref_vector disj(m);
         m_s->get_model(m_model);
         m_s->get_labels(m_labels);
         m_s->maximize_objectives(disj);
         set_max(m_lower, m_s->get_objective_values(), disj);
-        TRACE("opt",
-              for (unsigned i = 0; i < m_lower.size(); ++i) {
-                  tout << m_lower[i] << " ";
-              }
-              tout << "\n";
-              model_pp(tout, *m_model);
-              );
-        IF_VERBOSE(2, verbose_stream() << "(optsmt.lower ";
-                   for (unsigned i = 0; i < m_lower.size(); ++i) {
-                       verbose_stream() << m_lower[i] << " ";
-                   }
-                   verbose_stream() << ")\n";);
-        IF_VERBOSE(3, verbose_stream() << disj << "\n";);
-        IF_VERBOSE(3, model_pp(verbose_stream(), *m_model););
-
-        return expr_ref(m.mk_or(disj.size(), disj.c_ptr()), m);
+        TRACE("opt", model_pp(tout << m_lower << "\n", *m_model););
+        IF_VERBOSE(2, verbose_stream() << "(optsmt.lower " << m_lower << ")\n";);
+        return mk_or(disj);
     }
 
     lbool optsmt::update_upper() {
@@ -312,12 +477,21 @@ namespace opt {
         TRACE("opt", tout << "optsmt:lex\n";);
         solver::scoped_push _push(*m_s);
         SASSERT(obj_index < m_vars.size());
-        return basic_lex(obj_index, is_maximize);
+        if (is_maximize && m_optsmt_engine == symbol("farkas")) {
+            return farkas_opt();
+        }
+        else if (is_maximize && m_optsmt_engine == symbol("symba")) {
+            return symba_opt();
+        }
+        else {
+            return geometric_lex(obj_index, is_maximize);
+        }
     }
 
+    // deprecated
     lbool optsmt::basic_lex(unsigned obj_index, bool is_maximize) {
         lbool is_sat = l_true;
-        expr_ref block(m), tmp(m);
+        expr_ref bound(m);
 
         for (unsigned i = 0; i < obj_index; ++i) {
             commit_assignment(i);
@@ -326,25 +500,13 @@ namespace opt {
             is_sat = m_s->check_sat(0, 0); 
             if (is_sat != l_true) break;
             
-            m_s->maximize_objective(obj_index, block);
+            m_s->maximize_objective(obj_index, bound);
             m_s->get_model(m_model);
             m_s->get_labels(m_labels);
             inf_eps obj = m_s->saved_objective_value(obj_index);
-            if (obj > m_lower[obj_index]) {
-                m_lower[obj_index] = obj;                
-                IF_VERBOSE(1, 
-                           if (is_maximize) 
-                               verbose_stream() << "(optsmt lower bound: " << obj << ")\n";
-                           else
-                               verbose_stream() << "(optsmt upper bound: " << (-obj) << ")\n";
-                           );
-                for (unsigned i = obj_index+1; i < m_vars.size(); ++i) {
-                    m_s->maximize_objective(i, tmp);
-                    m_lower[i] = m_s->saved_objective_value(i);
-                }
-            }
-            TRACE("opt", tout << "strengthen bound: " << block << "\n";);
-            m_s->assert_expr(block);
+            update_lower_lex(obj_index, obj, is_maximize);
+            TRACE("opt", tout << "strengthen bound: " << bound << "\n";);
+            m_s->assert_expr(bound);
             
             // TBD: only works for simplex 
             // blocking formula should be extracted based
@@ -365,6 +527,7 @@ namespace opt {
     }
 
 
+
     /**
        Takes solver with hard constraints added.
        Returns an optimal assignment to objective functions.
@@ -383,7 +546,7 @@ namespace opt {
             is_sat = symba_opt();
         }
         else {
-            is_sat = basic_opt();
+            is_sat = geometric_opt();
         }
         return is_sat;
     }

--- a/src/opt/optsmt.h
+++ b/src/opt/optsmt.h
@@ -69,18 +69,27 @@ namespace opt {
         void reset();
         
     private:
+
+        bool get_max_delta(vector<inf_eps> const& lower, unsigned& idx);
         
         lbool basic_opt();
+
+        lbool geometric_opt();
 
         lbool symba_opt();
 
         lbool basic_lex(unsigned idx, bool is_maximize);
+
+        lbool geometric_lex(unsigned idx, bool is_maximize);
 
         lbool farkas_opt();
 
         void set_max(vector<inf_eps>& dst, vector<inf_eps> const& src, expr_ref_vector& fmls);
 
         expr_ref update_lower();
+
+        void update_lower_lex(unsigned idx, inf_eps const& r, bool is_maximize);
+
 
         lbool update_upper();
 

--- a/src/parsers/smt/smtparser.cpp
+++ b/src/parsers/smt/smtparser.cpp
@@ -1574,7 +1574,7 @@ private:
                     }
                 }
                 expr * p = m_manager.mk_pattern(ts.size(), (app*const*)(ts.c_ptr()));
-                if (!p || (!ignore_user_patterns() && !m_pattern_validator(num_bindings, p))) {
+                if (!p || (!ignore_user_patterns() && !m_pattern_validator(num_bindings, p, children[0]->line(), children[0]->pos()))) {
                     set_error("invalid pattern", children[0]);
                     return false;
                 }
@@ -1583,7 +1583,7 @@ private:
             else if (children[0]->string() == symbol("ex_act") && ts.size() == 1) {
                 app * sk_hack = m_manager.mk_app(m_sk_hack, 1, ts.c_ptr());
                 expr * p = m_manager.mk_pattern(1, &sk_hack);
-                if (!p || (!ignore_user_patterns() && !m_pattern_validator(num_bindings, p))) {
+                if (!p || (!ignore_user_patterns() && !m_pattern_validator(num_bindings, p, children[0]->line(), children[0]->pos()))) {
                     set_error("invalid pattern", children[0]);
                     return false;
                 }

--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -1605,7 +1605,7 @@ namespace smt2 {
             unsigned j = begin_pats;
             for (unsigned i = begin_pats; i < end_pats; i++) {
                 expr * pat = pattern_stack().get(i);
-                if (!pat_validator()(num_decls, pat)) {
+                if (!pat_validator()(num_decls, pat, m_scanner.get_line(), m_scanner.get_pos())) {
                     if (!ignore_bad_patterns())
                         throw parser_exception("invalid pattern");
                     continue;

--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -473,6 +473,7 @@ namespace smt2 {
 
         void parse_sexpr() {
             unsigned stack_pos  = sexpr_stack().size();
+            (void)stack_pos;
             unsigned num_frames = 0;
             do {
                 unsigned line = m_scanner.get_line();
@@ -631,6 +632,7 @@ namespace smt2 {
 
         void parse_psort() {
             unsigned stack_pos  = psort_stack().size();
+            (void)stack_pos;
             unsigned num_frames = 0;
             do {
                 if (curr_is_identifier()) {
@@ -693,6 +695,7 @@ namespace smt2 {
 
         void parse_sort(char const* context) {
             unsigned stack_pos  = sort_stack().size();
+            (void)stack_pos;
             unsigned num_frames = 0;
             do {
                 if (curr_is_identifier()) {

--- a/src/parsers/util/pattern_validation.cpp
+++ b/src/parsers/util/pattern_validation.cpp
@@ -31,16 +31,19 @@ struct pattern_validation_functor {
     bool       m_found_a_var;
     family_id  m_bfid;
     family_id  m_lfid;
+    unsigned   m_line, m_pos;
     
     pattern_validation_functor(uint_set & found_vars, unsigned num_bindings, unsigned num_new_bindings, 
-                               family_id bfid, family_id lfid):
+                               family_id bfid, family_id lfid, unsigned line, unsigned pos):
         m_found_vars(found_vars),
         m_num_bindings(num_bindings),
         m_num_new_bindings(num_new_bindings),
         m_result(true),
         m_found_a_var(false),
         m_bfid(bfid),
-        m_lfid(lfid) {
+        m_lfid(lfid),
+        m_line(line),
+        m_pos(pos) {
     }
 
     bool is_forbidden(func_decl const * decl) {
@@ -55,7 +58,7 @@ struct pattern_validation_functor {
     void operator()(app * n) {
         func_decl * decl = to_app(n)->get_decl();
         if (is_forbidden(decl)) {
-            warning_msg("'%s' cannot be used in patterns.", decl->get_name().str().c_str());
+            warning_msg("(%d,%d): '%s' cannot be used in patterns.", m_line, m_pos, decl->get_name().str().c_str());
             m_result = false;
         }
     }
@@ -63,7 +66,7 @@ struct pattern_validation_functor {
     void operator()(var * v) {
         unsigned idx = to_var(v)->get_idx();
         if (idx >= m_num_bindings) {
-            warning_msg("free variables cannot be used in patterns.");
+            warning_msg("(%d,%d): free variables cannot be used in patterns.", m_line, m_pos);
             m_result = false;
             return;
         }
@@ -76,30 +79,30 @@ struct pattern_validation_functor {
     void operator()(quantifier * q) { m_result = false; }
 };
 
-bool pattern_validator::process(uint_set & found_vars, unsigned num_bindings, unsigned num_new_bindings, expr * n) {
+bool pattern_validator::process(uint_set & found_vars, unsigned num_bindings, unsigned num_new_bindings, expr * n, unsigned line, unsigned pos) {
     // I'm traversing the DAG as a tree, this is not a problem since pattern are supposed to be small ASTs.
     if (n->get_kind() == AST_VAR) {
-        warning_msg("invalid pattern: variable.");
+        warning_msg("(%d,%d): invalid pattern: variable.", line, pos);
         return false;
     }
 
-    pattern_validation_functor f(found_vars, num_bindings, num_new_bindings, m_bfid, m_lfid);
+    pattern_validation_functor f(found_vars, num_bindings, num_new_bindings, m_bfid, m_lfid, line, pos);
     for_each_expr(f, n);
     if (!f.m_result)
         return false;
     if (!f.m_found_a_var) {
-        warning_msg("pattern does not contain any variable.");
+        warning_msg("(%d,%d): pattern does not contain any variable.", line, pos);
         return false;
     }
     return true;
 }
 
-bool pattern_validator::operator()(unsigned num_bindings, unsigned num_new_bindings, expr * n) {
+bool pattern_validator::operator()(unsigned num_bindings, unsigned num_new_bindings, expr * n, unsigned line, unsigned pos) {
     uint_set found_vars;
-    if (!process(found_vars, num_bindings, num_new_bindings, n))
+    if (!process(found_vars, num_bindings, num_new_bindings, n, line, pos))
         return false;
     bool r = found_vars.num_elems() == num_new_bindings;
     if (!r)
-        warning_msg("pattern does not contain all quantified variables.");
+        warning_msg("(%d,%d): pattern does not contain all quantified variables.", line, pos);
     return r;
 }

--- a/src/parsers/util/pattern_validation.h
+++ b/src/parsers/util/pattern_validation.h
@@ -27,7 +27,7 @@ class pattern_validator {
     family_id          m_bfid;
     family_id          m_lfid;
 
-    bool process(uint_set & found_vars, unsigned num_bindings, unsigned num_new_bindings, expr * n);
+    bool process(uint_set & found_vars, unsigned num_bindings, unsigned num_new_bindings, expr * n, unsigned line, unsigned pos);
 
 public:
     pattern_validator(ast_manager const & m):
@@ -35,8 +35,8 @@ public:
         m_lfid(m.get_label_family_id()) {
     }
 
-    bool operator()(unsigned num_bindings, unsigned num_new_bindings, expr * n);
-    bool operator()(unsigned num_new_bindings, expr * n) { return operator()(UINT_MAX, num_new_bindings, n); }
+    bool operator()(unsigned num_bindings, unsigned num_new_bindings, expr * n, unsigned line, unsigned pos);
+    bool operator()(unsigned num_new_bindings, expr * n, unsigned line, unsigned pos) { return operator()(UINT_MAX, num_new_bindings, n, line, pos); }
 };
 
 #endif /* PATTERN_VALIDATION_H_ */

--- a/src/qe/nlqsat.cpp
+++ b/src/qe/nlqsat.cpp
@@ -435,12 +435,11 @@ namespace qe {
         };
 
         class div_rewriter_cfg : public default_rewriter_cfg {
-            nlqsat&       s;
             ast_manager&  m;
             arith_util    a;
             vector<div>   m_divs;
         public:
-            div_rewriter_cfg(nlqsat& s): s(s), m(s.m), a(s.m) {}
+            div_rewriter_cfg(nlqsat& s): m(s.m), a(s.m) {}
             ~div_rewriter_cfg() {}
             br_status reduce_app(func_decl* f, unsigned sz, expr* const* args, expr_ref& result, proof_ref& pr) {
                 if (is_decl_of(f, a.get_family_id(), OP_DIV) && sz == 2 && !a.is_numeral(args[1]) && is_ground(args[0]) && is_ground(args[1])) {

--- a/src/qe/qe.cpp
+++ b/src/qe/qe.cpp
@@ -861,11 +861,12 @@ namespace qe {
 
         void operator()(expr_ref& fml, atom_set& pos, atom_set& neg) {
             expr_ref orig(fml);
-            ast_manager& m = fml.get_manager();
             m_nnf_core(fml);
             m_normalize_literals(fml);
             m_collect_atoms(fml, pos, neg);
-            TRACE("qe", tout << mk_ismt2_pp(orig, m) << "\n-->\n" << mk_ismt2_pp(fml, m) << "\n";);
+            TRACE("qe",
+                  ast_manager& m = fml.get_manager(); 
+                  tout << mk_ismt2_pp(orig, m) << "\n-->\n" << mk_ismt2_pp(fml, m) << "\n";);
         }      
 
         void reset() {

--- a/src/qe/qe.cpp
+++ b/src/qe/qe.cpp
@@ -1899,8 +1899,7 @@ namespace qe {
         // The variable v is to be assigned a value in a range.
         // 
         void constrain_assignment() {
-            expr* fml = m_current->fml();
-            SASSERT(fml);
+            SASSERT(m_current->fml());
             rational k;
             app* x;
             if (!find_min_weight(x, k)) {

--- a/src/qe/qe_arith.cpp
+++ b/src/qe/qe_arith.cpp
@@ -24,9 +24,9 @@ Revision History:
 #include "ast_util.h"
 #include "arith_decl_plugin.h"
 #include "ast_pp.h"
+#include "model_v2_pp.h"
 #include "th_rewriter.h"
 #include "expr_functors.h"
-#include "model_v2_pp.h"
 #include "expr_safe_replace.h"
 #include "model_based_opt.h"
 
@@ -103,19 +103,19 @@ namespace qe {
             expr_ref t(m);
             opt::ineq_type ty = opt::t_le;
             expr* e1, *e2;
+            DEBUG_CODE(expr_ref val(m); VERIFY(model.eval(lit, val) && m.is_true(val)););
+
             bool is_not = m.is_not(lit, lit);
             if (is_not) {
                 mul.neg();
             }
             SASSERT(!m.is_not(lit));
             if (a.is_le(lit, e1, e2) || a.is_ge(lit, e2, e1)) {
-                if (is_not) mul.neg();
                 linearize(mbo, model, mul, e1, c, ts, tids);
                 linearize(mbo, model, -mul, e2, c, ts, tids);
                 ty = is_not ? opt::t_lt : opt::t_le;
             }
             else if (a.is_lt(lit, e1, e2) || a.is_gt(lit, e2, e1)) {
-                if (is_not) mul.neg();
                 linearize(mbo, model,  mul, e1, c, ts, tids);
                 linearize(mbo, model, -mul, e2, c, ts, tids);
                 ty = is_not ? opt::t_le: opt::t_lt;

--- a/src/qe/qe_arith.cpp
+++ b/src/qe/qe_arith.cpp
@@ -29,6 +29,7 @@ Revision History:
 #include "expr_functors.h"
 #include "expr_safe_replace.h"
 #include "model_based_opt.h"
+#include "model_evaluator.h"
 
 namespace qe {
 
@@ -658,6 +659,9 @@ namespace qe {
             bool new_max = true;
             rational max_r, r;
             expr_ref val(m);
+            model_evaluator eval(mdl);
+            eval.set_model_completion(true);
+            
             bool is_int = a.is_int(m_var->x());
             for (unsigned i = 0; i < num_ineqs(); ++i) {
                 rational const& ac = m_ineq_coeffs[i];
@@ -669,7 +673,7 @@ namespace qe {
                 // ac < 0: x + t/ac > 0 <=> x > max { - t/ac | ac < 0 } = max { t/|ac| | ac < 0 } 
                 //
                 if (ac.is_pos() == do_pos) {
-                    VERIFY(mdl.eval(ineq_term(i), val));
+                    eval(ineq_term(i), val);
                     VERIFY(a.is_numeral(val, r));
                     r /= abs(ac);
                     new_max =

--- a/src/qe/qe_arith.h
+++ b/src/qe/qe_arith.h
@@ -29,6 +29,8 @@ namespace qe {
         virtual bool operator()(model& model, app* var, app_ref_vector& vars, expr_ref_vector& lits);
         virtual bool solve(model& model, app_ref_vector& vars, expr_ref_vector& lits);
         virtual family_id get_family_id();
+        virtual void operator()(model& model, app_ref_vector& vars, expr_ref_vector& lits);
+
 
         opt::inf_eps maximize(expr_ref_vector const& fmls, model& mdl, app* t, expr_ref& bound);
     };

--- a/src/qe/qe_arith_plugin.cpp
+++ b/src/qe/qe_arith_plugin.cpp
@@ -1153,21 +1153,20 @@ namespace qe {
         
 
         bool get_bound(contains_app& contains_x, app* a) {
-            ast_manager& m = m_util.get_manager();
-            app* x = contains_x.x();
-            if (m_mark.is_marked(a) ||
+            bool has_bound = 
+                m_mark.is_marked(a) ||
                 get_le_bound(contains_x, a) ||
                 get_lt_bound(contains_x, a) ||
                 get_divides(contains_x, a) ||
-                get_nested_divs(contains_x, a)) {
-                TRACE("qe_verbose", tout << "Bound for " << mk_pp(x, m) << " within " << mk_pp(a, m) << "\n";);
+                get_nested_divs(contains_x, a);
+            if (has_bound) {
                 m_mark.mark(a, true);
-                return true;
             }
-            else {
-                TRACE("qe", tout << "No bound for " << mk_pp(x, m) << " within " << mk_pp(a, m) << "\n";);
-                return false;
-            }
+            TRACE("qe_verbose", 
+                  ast_manager& m = m_util.get_manager();
+                  app* x = contains_x.x();
+                  tout << has_bound << " bound for " << mk_pp(x, m) << " within " << mk_pp(a, m) << "\n";);
+            return has_bound;
         }
 
         unsigned lt_size() { return m_lt_terms.size(); }
@@ -2323,7 +2322,6 @@ public:
             unsigned sz = bounds.size(is_strict, !is_lower);
             bool is_strict_real = !is_eq_ctx && m_util.is_real(x) && !is_strict_ctx;                   
             bool strict_resolve = is_strict || is_strict_ctx || is_strict_real;
-            app* atm = bounds.atoms(is_strict_ctx, is_lower)[index];    
 
             for (unsigned i = 0; i < sz; ++i) {
                 app* e = bounds.atoms(is_strict, !is_lower)[i];
@@ -2341,6 +2339,7 @@ public:
                 m_ctx.add_constraint(true, mk_not(e), tmp);
 
                 TRACE("qe_verbose", 
+                      app* atm = bounds.atoms(is_strict_ctx, is_lower)[index];    
                       tout << mk_pp(atm, m) << " ";
                       tout << mk_pp(e, m) << " ==>\n";
                       tout << mk_pp(tmp, m) << "\n";

--- a/src/qe/qe_mbp.cpp
+++ b/src/qe/qe_mbp.cpp
@@ -194,7 +194,6 @@ class mbp::impl {
 
 
     void filter_variables(model& model, app_ref_vector& vars, expr_ref_vector& lits, expr_ref_vector& unused_lits) {
-        ast_manager& m = vars.get_manager();
         expr_mark lit_visited;
         project_plugin::mark_rec(lit_visited, lits);
 

--- a/src/qe/qe_mbp.h
+++ b/src/qe/qe_mbp.h
@@ -37,6 +37,7 @@ namespace qe {
         virtual bool operator()(model& model, app* var, app_ref_vector& vars, expr_ref_vector& lits) = 0;
         virtual bool solve(model& model, app_ref_vector& vars, expr_ref_vector& lits) = 0;
         virtual family_id get_family_id() = 0;
+        virtual bool operator()(model& model, app_ref_vector& vars, expr_ref_vector& lits) { return false; };
 
         static expr_ref pick_equality(ast_manager& m, model& model, expr* t);
         static void partition_values(model& model, expr_ref_vector const& vals, expr_ref_vector& lits);

--- a/src/qe/qe_mbp.h
+++ b/src/qe/qe_mbp.h
@@ -37,13 +37,15 @@ namespace qe {
         virtual bool operator()(model& model, app* var, app_ref_vector& vars, expr_ref_vector& lits) = 0;
         virtual bool solve(model& model, app_ref_vector& vars, expr_ref_vector& lits) = 0;
         virtual family_id get_family_id() = 0;
-        virtual bool operator()(model& model, app_ref_vector& vars, expr_ref_vector& lits) { return false; };
+        virtual void operator()(model& model, app_ref_vector& vars, expr_ref_vector& lits) { };
 
         static expr_ref pick_equality(ast_manager& m, model& model, expr* t);
         static void partition_values(model& model, expr_ref_vector const& vals, expr_ref_vector& lits);
         static void partition_args(model& model, app_ref_vector const& sels, expr_ref_vector& lits);
         static void erase(expr_ref_vector& lits, unsigned& i);
         static void push_back(expr_ref_vector& lits, expr* lit);
+        static void mark_rec(expr_mark& visited, expr* e);
+        static void mark_rec(expr_mark& visited, expr_ref_vector const& es);
     };
 
     class mbp {

--- a/src/qe/qe_sat_tactic.cpp
+++ b/src/qe/qe_sat_tactic.cpp
@@ -603,8 +603,7 @@ namespace qe {
                 m_solver.assert_expr(m.mk_iff(proxies.back(), m_assignments[i].get()));
                 TRACE("qe", tout << "assignment: " << mk_pp(m_assignments[i].get(), m) << "\n";);
             }
-            lbool is_sat = m_solver.check(proxies.size(), proxies.c_ptr());
-            SASSERT(is_sat == l_false);
+            VERIFY(l_false == m_solver.check(proxies.size(), proxies.c_ptr()));
             unsigned core_size = m_solver.get_unsat_core_size();
             for (unsigned i = 0; i < core_size; ++i) {
                 core.push_back(proxy_map.find(m_solver.get_unsat_core_expr(i)));

--- a/src/qe/qsat.cpp
+++ b/src/qe/qsat.cpp
@@ -575,6 +575,7 @@ namespace qe {
         lbool check_sat() {        
             while (true) {
                 ++m_stats.m_num_rounds;
+                IF_VERBOSE(3, verbose_stream() << "(check-qsat level: " << m_level << " round: " << m_stats.m_num_rounds << ")\n";);
                 check_cancel();
                 expr_ref_vector asms(m_asms);
                 m_pred_abs.get_assumptions(m_model.get(), asms);
@@ -1191,7 +1192,7 @@ namespace qe {
 
         lbool maximize(expr_ref_vector const& fmls, app* t, model_ref& mdl, opt::inf_eps& value) {
             expr_ref_vector defs(m);
-            expr_ref fml = negate_core(fmls);
+            expr_ref fml = mk_and(fmls);
             hoist(fml);
             m_objective = t;
             m_value = opt::inf_eps();

--- a/src/qe/qsat.cpp
+++ b/src/qe/qsat.cpp
@@ -503,13 +503,11 @@ namespace qe {
     }
 
     class kernel {
-        ast_manager& m;
         smt_params   m_smtp;
         smt::kernel  m_kernel;
         
     public:
         kernel(ast_manager& m):
-            m(m),
             m_kernel(m, m_smtp)
         {
             m_smtp.m_model = true;

--- a/src/qe/qsat.h
+++ b/src/qe/qsat.h
@@ -114,6 +114,16 @@ namespace qe {
         void collect_statistics(statistics& st) const;
     };
 
+    class qmax {
+        struct imp;
+        imp* m_imp;
+    public:
+        qmax(ast_manager& m, params_ref const& p = params_ref());
+        ~qmax();
+        lbool operator()(expr_ref_vector const& fmls, app* t, opt::inf_eps& value, model_ref& mdl);
+        void collect_statistics(statistics& st) const;
+    };
+
     lbool maximize(expr_ref_vector const& fmls, app* t, opt::inf_eps& value, model_ref& mdl, params_ref const& p);
 
 }

--- a/src/qe/qsat.h
+++ b/src/qe/qsat.h
@@ -114,6 +114,17 @@ namespace qe {
         void collect_statistics(statistics& st) const;
     };
 
+    class max_min_opt {
+        struct imp;
+        imp* m_imp;
+    public:
+        max_min_opt(ast_manager& m, params_ref const& p = params_ref());
+        ~max_min_opt();
+        void add(expr* e);
+        void add(expr_ref_vector const& fmls);
+        lbool check(svector<bool> const& is_max, app_ref_vector const& vars, app* t);
+    };
+
     lbool maximize(expr_ref_vector const& fmls, app* t, opt::inf_eps& value, model_ref& mdl, params_ref const& p);
 
 }

--- a/src/qe/qsat.h
+++ b/src/qe/qsat.h
@@ -114,17 +114,6 @@ namespace qe {
         void collect_statistics(statistics& st) const;
     };
 
-    class max_min_opt {
-        struct imp;
-        imp* m_imp;
-    public:
-        max_min_opt(ast_manager& m, params_ref const& p = params_ref());
-        ~max_min_opt();
-        void add(expr* e);
-        void add(expr_ref_vector const& fmls);
-        lbool check(svector<bool> const& is_max, app_ref_vector const& vars, app* t);
-    };
-
     lbool maximize(expr_ref_vector const& fmls, app* t, opt::inf_eps& value, model_ref& mdl, params_ref const& p);
 
 }

--- a/src/sat/sat_bceq.cpp
+++ b/src/sat/sat_bceq.cpp
@@ -345,10 +345,11 @@ namespace sat {
     }
 
     void bceq::verify_sweep() {
-        for (unsigned i = 0; i < m_L.size(); ++i) {
-            uint64 b = eval_clause(*m_L[i]);
-            SASSERT((~b) == 0);
-        }
+        DEBUG_CODE(
+            for (unsigned i = 0; i < m_L.size(); ++i) {
+                uint64 b = eval_clause(*m_L[i]);
+                SASSERT((~b) == 0);
+            });
     }
 
     struct u64_hash { unsigned operator()(uint64 u) const { return (unsigned)u; } };

--- a/src/sat/sat_clause.cpp
+++ b/src/sat/sat_clause.cpp
@@ -52,6 +52,7 @@ namespace sat {
 
     bool clause::check_approx() const {
         var_approx_set curr = m_approx;
+        (void)curr;
         const_cast<clause*>(this)->update_approx();
         SASSERT(may_eq(curr, m_approx));
         return true;

--- a/src/sat/sat_clause_set.cpp
+++ b/src/sat/sat_clause_set.cpp
@@ -35,6 +35,8 @@ namespace sat {
         unsigned id = c.id();
         if (id >= m_id2pos.size())
             return;
+        if (empty()) 
+            return;
         unsigned pos = m_id2pos[id];
         if (pos == UINT_MAX)
             return;
@@ -52,7 +54,11 @@ namespace sat {
     clause & clause_set::erase() {
         SASSERT(!empty());
         clause & c = *m_set.back(); 
-        m_id2pos[c.id()] = UINT_MAX;
+        SASSERT(c.id() < m_id2pos.size());
+        SASSERT(m_id2pos[c.id()] == m_set.size()-1);
+        if (c.id() < m_id2pos.size()) {
+            m_id2pos[c.id()] = UINT_MAX;
+        }
         m_set.pop_back();
         return c;
     }

--- a/src/sat/sat_clause_set.cpp
+++ b/src/sat/sat_clause_set.cpp
@@ -64,6 +64,7 @@ namespace sat {
     }
 
     bool clause_set::check_invariant() const {
+        DEBUG_CODE(
         {
             clause_vector::const_iterator it  = m_set.begin();
             clause_vector::const_iterator end = m_set.end();
@@ -83,7 +84,7 @@ namespace sat {
                 SASSERT(pos < m_set.size());
                 SASSERT(m_set[pos]->id() == id);
             }
-        }
+        });
         return true;
     }
 

--- a/src/sat/sat_integrity_checker.cpp
+++ b/src/sat/sat_integrity_checker.cpp
@@ -159,7 +159,8 @@ namespace sat {
         for (unsigned l_idx = 0; it != end; ++it, ++l_idx) {
             literal l = ~to_literal(l_idx);            
             watch_list const & wlist = *it;
-            CTRACE("sat_bug", s.was_eliminated(l.var()) && !wlist.empty(),
+            CTRACE("sat_bug", 
+                   s.was_eliminated(l.var()) && !wlist.empty(),
                    tout << "l: " << l << "\n";
                    s.display_watches(tout);
                    s.display(tout););
@@ -179,7 +180,7 @@ namespace sat {
                            tout << "\n";
                            sat::display(tout, s.m_cls_allocator, s.get_wlist(~(it2->get_literal())));
                            tout << "\n";);
-                    SASSERT(s.get_wlist(~(it2->get_literal())).contains(watched(l, it2->is_learned())));
+                        SASSERT(s.get_wlist(~(it2->get_literal())).contains(watched(l, it2->is_learned())));
                     break;
                 case watched::TERNARY:
                     SASSERT(!s.was_eliminated(it2->get_literal1().var()));

--- a/src/sat/sat_integrity_checker.cpp
+++ b/src/sat/sat_integrity_checker.cpp
@@ -40,8 +40,7 @@ namespace sat {
             if (it->is_clause()) {
                 if (it->get_clause_offset() == cls_off) {
                     // the blocked literal must be in the clause.
-                    literal l = it->get_blocked_literal();
-                    SASSERT(c.contains(l));
+                    SASSERT(c.contains(it->get_blocked_literal()));
                     return true;
                 }
             }
@@ -154,10 +153,11 @@ namespace sat {
     }
 
     bool integrity_checker::check_watches() const {
+        DEBUG_CODE(
         vector<watch_list>::const_iterator it  = s.m_watches.begin();
         vector<watch_list>::const_iterator end = s.m_watches.end();
         for (unsigned l_idx = 0; it != end; ++it, ++l_idx) {
-            literal l = ~to_literal(l_idx);
+            literal l = ~to_literal(l_idx);            
             watch_list const & wlist = *it;
             CTRACE("sat_bug", s.was_eliminated(l.var()) && !wlist.empty(),
                    tout << "l: " << l << "\n";
@@ -193,7 +193,7 @@ namespace sat {
                     break;
                 }
             }
-        }
+        });
         return true;
     }
 

--- a/src/sat/sat_solver.cpp
+++ b/src/sat/sat_solver.cpp
@@ -80,8 +80,7 @@ namespace sat {
                 SASSERT(!src.was_eliminated(v));
                 bool ext  = src.m_external[v] != 0;
                 bool dvar = src.m_decision[v] != 0;
-                bool_var new_v = mk_var(ext, dvar);
-                SASSERT(v == new_v);
+                VERIFY(v == mk_var(ext, dvar));
             }
         }
         {
@@ -407,9 +406,8 @@ namespace sat {
         unsigned num_lits = cls.size();
         for (unsigned i = 1; i < num_lits; i++) {
             literal l    = cls[i];
-            lbool val    = value(l);
-            CTRACE("sat", val != l_false, tout << l << ":=" << val;);
-            SASSERT(val == l_false);
+            CTRACE("sat", value(l) != l_false, tout << l << ":=" << value(l););
+            SASSERT(value(l) == l_false);
             if (max_false_idx == UINT_MAX || lvl(l) > lvl(cls[max_false_idx]))
                 max_false_idx = i;
         }

--- a/src/smt/diff_logic.h
+++ b/src/smt/diff_logic.h
@@ -739,6 +739,7 @@ public:
         if (idx2 < idx1) {
             std::swap(idx1,idx2);
         }        
+        (void) max_idx;
         SASSERT(idx1 < idx2 && idx2 < edges.size());
         SASSERT(max_idx < edges.size());
         dst = get_source(edges[idx2]);

--- a/src/smt/mam.cpp
+++ b/src/smt/mam.cpp
@@ -1856,6 +1856,7 @@ namespace smt {
         ptr_vector<enode>   m_used_enodes;
         unsigned            m_curr_used_enodes_size;
         ptr_vector<enode>   m_pattern_instances; // collect the pattern instances... used for computing min_top_generation and max_top_generation
+        unsigned_vector     m_min_top_generation, m_max_top_generation;
 
         pool<enode_vector>  m_pool;
 
@@ -2034,28 +2035,26 @@ namespace smt {
         // init(t) must be invoked before execute_core
         void execute_core(code_tree * t, enode * n);
 
-        // Return the min generation of the enodes in m_pattern_instances.
-        unsigned get_min_top_generation() const {
-            SASSERT(!m_pattern_instances.empty());
-            unsigned min = m_pattern_instances[0]->get_generation();
-            for (unsigned i = 1; i < m_pattern_instances.size(); i++) {
-                unsigned curr = m_pattern_instances[i]->get_generation();
-                if (min > curr)
-                    min = curr;
-            }
-            return min;
-        }
+        // Return the min, max generation of the enodes in m_pattern_instances.
 
-        // Return the max generation of the enodes in m_pattern_instances.
-        unsigned get_max_top_generation() const {
+        void get_min_max_top_generation(unsigned& min, unsigned& max) {
             SASSERT(!m_pattern_instances.empty());
-            unsigned max = m_pattern_instances[0]->get_generation();
-            for (unsigned i = 1; i < m_pattern_instances.size(); i++) {
-                unsigned curr = m_pattern_instances[i]->get_generation();
-                if (max < curr)
-                    max = curr;
+            if (m_min_top_generation.empty()) {
+                min = max = m_pattern_instances[0]->get_generation();
+                m_min_top_generation.push_back(min);
+                m_max_top_generation.push_back(max);
             }
-            return max;
+            else {
+                min = m_min_top_generation.back();
+                max = m_max_top_generation.back();
+            }
+            for (unsigned i = m_min_top_generation.size(); i < m_pattern_instances.size(); ++i) {
+                unsigned curr = m_pattern_instances[i]->get_generation();
+                min = std::min(min, curr);
+                m_min_top_generation.push_back(min);
+                max = std::max(max, curr);
+                m_max_top_generation.push_back(max);
+            }
         }
     };
 
@@ -2278,6 +2277,8 @@ namespace smt {
         TRACE("mam_execute_core", tout << "EXEC " << t->get_root_lbl()->get_name() << "\n";);
         SASSERT(m_context.is_relevant(n));
         m_pattern_instances.reset();
+        m_min_top_generation.reset();
+        m_max_top_generation.reset();
         m_pattern_instances.push_back(n);
         m_max_generation = n->get_generation();
 
@@ -2289,8 +2290,10 @@ namespace smt {
         m_pc             = t->get_root();
         m_registers[0]   = n;
         m_top            = 0;
+
         
     main_loop:
+
         TRACE("mam_int", display_pc_info(tout););
 #ifdef _PROFILE_MAM
         const_cast<instruction*>(m_pc)->m_counter++;
@@ -2497,8 +2500,11 @@ namespace smt {
 
         case YIELD1:
             m_bindings[0] = m_registers[static_cast<const yield *>(m_pc)->m_bindings[0]];
-#define ON_MATCH(NUM)                                                                                   \
+#define ON_MATCH(NUM)                                                   \
             m_max_generation = std::max(m_max_generation, get_max_generation(NUM, m_bindings.begin())); \
+            if (m_context.get_cancel_flag()) {                          \
+                return;                                                 \
+            }                                                           \
             m_mam.on_match(static_cast<const yield *>(m_pc)->m_qa,                                      \
                            static_cast<const yield *>(m_pc)->m_pat,                                     \
                            NUM,                                                                         \
@@ -2770,9 +2776,12 @@ namespace smt {
                 if (m_app->get_num_args() == c->m_num_args && m_context.is_relevant(m_app)) {
                     // update the pattern instance
                     SASSERT(!m_pattern_instances.empty());
+                    if (m_pattern_instances.size() == m_max_top_generation.size()) {
+                        m_max_top_generation.pop_back();
+                        m_min_top_generation.pop_back();
+                    }
                     m_pattern_instances.pop_back();
                     m_pattern_instances.push_back(m_app);
-                    
                     // continue succeeded
                     update_max_generation(m_app);
                     TRACE("mam_int", tout << "continue next candidate:\n" << mk_ll_pp(m_app->get_owner(), m_ast_manager););
@@ -3932,7 +3941,9 @@ namespace smt {
                 SASSERT(bindings[i]->get_generation() <= max_generation);
             }
 #endif
-            m_context.add_instance(qa, pat, num_bindings, bindings, max_generation, m_interpreter.get_min_top_generation(), m_interpreter.get_max_top_generation(), used_enodes);
+            unsigned min_gen, max_gen;
+            m_interpreter.get_min_max_top_generation(min_gen, max_gen);
+            m_context.add_instance(qa, pat, num_bindings, bindings, max_generation, min_gen, max_gen, used_enodes);
         }
 
         virtual bool is_shared(enode * n) const {

--- a/src/smt/qi_queue.cpp
+++ b/src/smt/qi_queue.cpp
@@ -377,11 +377,10 @@ namespace smt {
             bool result = true;
             for (unsigned i = 0; i < sz; i++) {
                 entry & e       = m_delayed_entries[i];
-                fingerprint * f = e.m_qb;
-                TRACE("qi_queue", tout << f << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
+                TRACE("qi_queue", tout << e.m_qb << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
                 if (!e.m_instantiated && e.m_cost <= min_cost) {
                     TRACE("qi_queue", 
-                          tout << "lazy quantifier instantiation...\n" << mk_pp(static_cast<quantifier*>(f->get_data()), m_manager) << "\ncost: " << e.m_cost << "\n";);
+                          tout << "lazy quantifier instantiation...\n" << mk_pp(static_cast<quantifier*>(e.m_qb->get_data()), m_manager) << "\ncost: " << e.m_cost << "\n";);
                     result             = false;
                     m_instantiated_trail.push_back(i);
                     m_stats.m_num_lazy_instances++;
@@ -394,11 +393,10 @@ namespace smt {
         bool result = true;
         for (unsigned i = 0; i < m_delayed_entries.size(); i++) {
             entry & e       = m_delayed_entries[i];
-            fingerprint * f = e.m_qb;
-            TRACE("qi_queue", tout << f << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
+            TRACE("qi_queue", tout << e.m_qb << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
             if (!e.m_instantiated && e.m_cost <= m_params.m_qi_lazy_threshold)  {
                 TRACE("qi_queue", 
-                      tout << "lazy quantifier instantiation...\n" << mk_pp(static_cast<quantifier*>(f->get_data()), m_manager) << "\ncost: " << e.m_cost << "\n";);
+                      tout << "lazy quantifier instantiation...\n" << mk_pp(static_cast<quantifier*>(e.m_qb->get_data()), m_manager) << "\ncost: " << e.m_cost << "\n";);
                 result             = false;
                 m_instantiated_trail.push_back(i);
                 m_stats.m_num_lazy_instances++;

--- a/src/smt/qi_queue.cpp
+++ b/src/smt/qi_queue.cpp
@@ -367,8 +367,7 @@ namespace smt {
             unsigned sz = m_delayed_entries.size();
             for (unsigned i = 0; i < sz; i++) {
                 entry & e       = m_delayed_entries[i];
-                fingerprint * f = e.m_qb;
-                TRACE("qi_queue", tout << f << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
+                TRACE("qi_queue", tout << e.m_qb << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
                 if (!e.m_instantiated && e.m_cost <= m_params.m_qi_lazy_threshold && (!init || e.m_cost < min_cost)) {
                     init = true;
                     min_cost = e.m_cost;
@@ -379,11 +378,10 @@ namespace smt {
             for (unsigned i = 0; i < sz; i++) {
                 entry & e       = m_delayed_entries[i];
                 fingerprint * f = e.m_qb;
-                quantifier * qa = static_cast<quantifier*>(f->get_data());
                 TRACE("qi_queue", tout << f << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
                 if (!e.m_instantiated && e.m_cost <= min_cost) {
                     TRACE("qi_queue", 
-                          tout << "lazy quantifier instantiation...\n" << mk_pp(qa, m_manager) << "\ncost: " << e.m_cost << "\n";);
+                          tout << "lazy quantifier instantiation...\n" << mk_pp(static_cast<quantifier*>(f->get_data()), m_manager) << "\ncost: " << e.m_cost << "\n";);
                     result             = false;
                     m_instantiated_trail.push_back(i);
                     m_stats.m_num_lazy_instances++;
@@ -397,11 +395,10 @@ namespace smt {
         for (unsigned i = 0; i < m_delayed_entries.size(); i++) {
             entry & e       = m_delayed_entries[i];
             fingerprint * f = e.m_qb;
-            quantifier * qa = static_cast<quantifier*>(f->get_data());
             TRACE("qi_queue", tout << f << ", cost: " << e.m_cost << ", instantiated: " << e.m_instantiated << "\n";);
             if (!e.m_instantiated && e.m_cost <= m_params.m_qi_lazy_threshold)  {
                 TRACE("qi_queue", 
-                      tout << "lazy quantifier instantiation...\n" << mk_pp(qa, m_manager) << "\ncost: " << e.m_cost << "\n";);
+                      tout << "lazy quantifier instantiation...\n" << mk_pp(static_cast<quantifier*>(f->get_data()), m_manager) << "\ncost: " << e.m_cost << "\n";);
                 result             = false;
                 m_instantiated_trail.push_back(i);
                 m_stats.m_num_lazy_instances++;

--- a/src/smt/smt_conflict_resolution.cpp
+++ b/src/smt/smt_conflict_resolution.cpp
@@ -99,9 +99,10 @@ namespace smt {
        This method may update m_antecedents, m_todo_js and m_todo_eqs.
     */
     void conflict_resolution::eq_justification2literals(enode * lhs, enode * rhs, eq_justification js) {
-        ast_manager& m = get_manager();
         SASSERT(m_antecedents);
-        TRACE("conflict_detail", tout << mk_pp(lhs->get_owner(), m) << " = " << mk_pp(rhs->get_owner(), m);
+        TRACE("conflict_detail", 
+              ast_manager& m = get_manager();
+              tout << mk_pp(lhs->get_owner(), m) << " = " << mk_pp(rhs->get_owner(), m);
               switch (js.get_kind()) {
               case eq_justification::AXIOM: tout << " axiom\n";  break;
               case eq_justification::EQUATION:

--- a/src/smt/smt_context.cpp
+++ b/src/smt/smt_context.cpp
@@ -2259,6 +2259,7 @@ namespace smt {
                     }
                     
                     unsigned ilvl       = 0;
+                    (void)ilvl;
                     for (unsigned j = 0; j < num; j++) {
                         expr * atom     = cls->get_atom(j);
                         bool   sign     = cls->get_atom_sign(j);
@@ -2855,8 +2856,7 @@ namespace smt {
         propagate();
         if (was_consistent && inconsistent()) {
             // logical context became inconsistent during user PUSH
-            bool res = resolve_conflict(); // build the proof
-            SASSERT(!res);
+            VERIFY(!resolve_conflict()); // build the proof
         }
         push_scope();
         m_base_scopes.push_back(base_scope());
@@ -3110,8 +3110,7 @@ namespace smt {
         else {
             TRACE("after_internalization", display(tout););
             if (inconsistent()) {
-                bool res = resolve_conflict(); // build the proof
-                SASSERT(!res);
+                VERIFY(!resolve_conflict()); // build the proof
                 r = l_false;
             }
             else {
@@ -3197,8 +3196,7 @@ namespace smt {
                 init_assumptions(num_assumptions, assumptions);
                 TRACE("after_internalization", display(tout););
                 if (inconsistent()) {
-                    bool res = resolve_conflict(); // build the proof
-                    SASSERT(!res);
+                    VERIFY(!resolve_conflict()); // build the proof
                     mk_unsat_core();
                     r = l_false;
                 }

--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -3545,10 +3545,9 @@ namespace smt {
         //
         // Since we only care about q (and its bindings), it only makes sense to restrict the variables of q.
         bool asserted_something = false;
-        quantifier * flat_q = get_flat_quantifier(q);
         unsigned num_decls      = q->get_num_decls();
         // Remark: sks were created for the flat version of q.
-        SASSERT(flat_q->get_num_decls() == sks.size());
+        SASSERT(get_flat_quantifier(q)->get_num_decls() == sks.size());
         SASSERT(sks.size() >= num_decls);
         for (unsigned i = 0; i < num_decls; i++) {
             expr * sk = sks.get(num_decls - i - 1);

--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -2899,15 +2899,16 @@ namespace smt {
             }
             
             bool check_satisfied_residue_invariant() {
-                qsset::iterator it  = m_satisfied.begin();
-                qsset::iterator end = m_satisfied.end();
-                for (; it != end; ++it) {
-                    quantifier * q = *it;
-                    SASSERT(!m_residue.contains(q));
-                    quantifier_info * qi = get_qinfo(q);
-                    SASSERT(qi != 0);
-                    SASSERT(qi->get_the_one() != 0);
-                }
+                DEBUG_CODE(
+                    qsset::iterator it  = m_satisfied.begin();
+                    qsset::iterator end = m_satisfied.end();
+                    for (; it != end; ++it) {
+                        quantifier * q = *it;
+                        SASSERT(!m_residue.contains(q));
+                        quantifier_info * qi = get_qinfo(q);
+                        SASSERT(qi != 0);
+                        SASSERT(qi->get_the_one() != 0);
+                    });
                 return true;
             }
 
@@ -3546,12 +3547,9 @@ namespace smt {
         bool asserted_something = false;
         quantifier * flat_q = get_flat_quantifier(q);
         unsigned num_decls      = q->get_num_decls();
-        unsigned flat_num_decls = flat_q->get_num_decls();
-        unsigned num_sks        = sks.size();
         // Remark: sks were created for the flat version of q.
-        SASSERT(num_sks == flat_num_decls);
-        SASSERT(flat_num_decls >= num_decls);
-        SASSERT(num_sks >= num_decls);
+        SASSERT(flat_q->get_num_decls() == sks.size());
+        SASSERT(sks.size() >= num_decls);
         for (unsigned i = 0; i < num_decls; i++) {
             expr * sk = sks.get(num_decls - i - 1);
             instantiation_set const * s = get_uvar_inst_set(q, i);

--- a/src/smt/theory_arith_aux.h
+++ b/src/smt/theory_arith_aux.h
@@ -813,7 +813,7 @@ namespace smt {
                 continue;
             if (proofs_enabled()) {
                 new_bound.push_lit(l, ante.lit_coeffs()[i]);
-            }			
+            }
             else {
                 new_bound.push_lit(l, numeral::zero());
                 lits.insert(l.index());

--- a/src/smt/theory_arith_aux.h
+++ b/src/smt/theory_arith_aux.h
@@ -1342,6 +1342,7 @@ namespace smt {
               tout << "v" << x_i << " ";
               tout << (has_shared?"shared":"not shared") << "\n";);
 
+        (void) empty_column;
         SASSERT(!safe_gain(min_gain, max_gain) ||
                 empty_column ||
                 (unbounded_gain(max_gain) == (x_i == null_theory_var)));

--- a/src/smt/theory_arith_aux.h
+++ b/src/smt/theory_arith_aux.h
@@ -1784,7 +1784,7 @@ namespace smt {
     template<typename Ext>
    typename theory_arith<Ext>::max_min_t theory_arith<Ext>::max_min(theory_var v, bool max, bool maintain_integrality, bool& has_shared) {
         expr* e = get_enode(v)->get_owner();
-
+        (void)e;
         SASSERT(!maintain_integrality || valid_assignment());
         SASSERT(satisfy_bounds());
         SASSERT(!is_quasi_base(v));

--- a/src/smt/theory_arith_core.h
+++ b/src/smt/theory_arith_core.h
@@ -1866,7 +1866,7 @@ namespace smt {
     template<typename Ext>
     template<bool Lazy>
     void theory_arith<Ext>::pivot(theory_var x_i, theory_var x_j, numeral const & a_ij, bool apply_gcd_test) {
-        TRACE("arith_pivot", tout << "pivoting: v" << x_i << ", v" << x_j << "\n";);
+        TRACE("arith_pivoting", tout << "pivoting: v" << x_i << ", v" << x_j << "\n";);
         m_stats.m_pivots++;
         SASSERT(is_base(x_i) || is_quasi_base(x_i));
         SASSERT(x_i != x_j);
@@ -2067,14 +2067,14 @@ namespace smt {
         theory_var max    = get_num_vars();
         theory_var result = max;
         row const & r     = m_rows[get_var_row(x_i)];
-        int n;
         int best_col_sz    = INT_MAX;
         int best_so_far    = INT_MAX;
-        
-        typename vector<row_entry>::const_iterator it  = r.begin_entries();
+        int n = 0;
+        typename vector<row_entry>::const_iterator it = r.begin_entries();
         typename vector<row_entry>::const_iterator end = r.end_entries();
-    
-        for (; it != end; ++it) {                                                                                   
+
+        for (; it != end; ++it) {
+
             if (!it->is_dead()) {                                                                                   
                 theory_var x_j       = it->m_var;                                                                             
                 numeral const & a_ij = it->m_coeff;  
@@ -2090,14 +2090,14 @@ namespace smt {
                         best_so_far   = num;
                         best_col_sz   = col_sz;
                         n             = 1;
-                    } 
+                    }
                     else if (num == best_so_far && col_sz == best_col_sz) {
                         n++;
                         if (m_random()%n == 0) {
                             result      = x_j;
                             out_a_ij    = a_ij;
                         }
-                    }                              
+                    }  
                 }
             }
         }
@@ -2174,6 +2174,7 @@ namespace smt {
         inf_numeral curr_error;
         typename var_heap::iterator it  = m_to_patch.begin();
         typename var_heap::iterator end = m_to_patch.end();
+        //unsigned n = 0;
         for (; it != end; ++it) {
             theory_var v = *it;
             if (below_lower(v))
@@ -2188,7 +2189,16 @@ namespace smt {
                       << ", best_error: " << best_error << ", curr_error: " << curr_error << "\n";);
                 best = v;
                 best_error = curr_error;
+                //n = 2;
             }
+#if 0
+            else if (false && n > 0 && curr_error == best_error) {
+                n++;
+                if (m_random()%n == 0) {
+                    best = v;
+                }
+            }
+#endif
         }
         if (best == null_theory_var)
             m_to_patch.clear(); // all variables are satisfied

--- a/src/smt/theory_array.cpp
+++ b/src/smt/theory_array.cpp
@@ -75,7 +75,7 @@ namespace smt {
         ast_manager& m = get_manager();
         context& ctx = get_context();
         theory_var r  = theory_array_base::mk_var(n);
-        VERIFY(r == m_find.mk_var());
+        VERIFY(r == static_cast<theory_var>(m_find.mk_var()));
         SASSERT(r == static_cast<int>(m_var_data.size()));
         m_var_data.push_back(alloc(var_data));
         var_data * d  = m_var_data[r];

--- a/src/smt/theory_array.cpp
+++ b/src/smt/theory_array.cpp
@@ -75,8 +75,7 @@ namespace smt {
         ast_manager& m = get_manager();
         context& ctx = get_context();
         theory_var r  = theory_array_base::mk_var(n);
-        theory_var r2 = m_find.mk_var();
-        SASSERT(r == r2);
+        VERIFY(r == m_find.mk_var());
         SASSERT(r == static_cast<int>(m_var_data.size()));
         m_var_data.push_back(alloc(var_data));
         var_data * d  = m_var_data[r];

--- a/src/smt/theory_bv.cpp
+++ b/src/smt/theory_bv.cpp
@@ -457,8 +457,7 @@ namespace smt {
 
     void theory_bv::fixed_var_eh(theory_var v) {
         numeral val;
-        bool r      = get_fixed_value(v, val);
-        SASSERT(r);
+        VERIFY(get_fixed_value(v, val));
         unsigned sz = get_bv_size(v);
         value_sort_pair key(val, sz);
         theory_var v2;
@@ -554,9 +553,8 @@ namespace smt {
 
     void theory_bv::internalize_bv2int(app* n) {
         SASSERT(!get_context().e_internalized(n));
-        ast_manager & m = get_manager();
         context& ctx = get_context();
-        TRACE("bv", tout << mk_bounded_pp(n, m) << "\n";);
+        TRACE("bv", tout << mk_bounded_pp(n, get_manager()) << "\n";);
         process_args(n);
         mk_enode(n);
         if (!ctx.relevancy()) {
@@ -1142,9 +1140,8 @@ namespace smt {
     }
 
     void theory_bv::assign_eh(bool_var v, bool is_true) {
-        context & ctx = get_context();
         atom * a      = get_bv2a(v);
-        TRACE("bv", tout << "assert: v" << v << " #" << ctx.bool_var2expr(v)->get_id() << " is_true: " << is_true << "\n";);
+        TRACE("bv", tout << "assert: v" << v << " #" << get_context().bool_var2expr(v)->get_id() << " is_true: " << is_true << "\n";);
         if (a->is_bit()) {
             // The following optimization is not correct.
             // Boolean variables created for performing bit-blasting are reused.

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -198,7 +198,7 @@ namespace smt {
 
     theory_var theory_datatype::mk_var(enode * n) {
         theory_var r  = theory::mk_var(n);
-        VERIFY(r == m_find.mk_var());
+        VERIFY(r == static_cast<theory_var>(m_find.mk_var()));
         SASSERT(r == static_cast<int>(m_var_data.size()));
         m_var_data.push_back(alloc(var_data));
         var_data * d  = m_var_data[r];

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -198,8 +198,7 @@ namespace smt {
 
     theory_var theory_datatype::mk_var(enode * n) {
         theory_var r  = theory::mk_var(n);
-        theory_var r2 = m_find.mk_var();
-        SASSERT(r == r2);
+        VERIFY(r == m_find.mk_var());
         SASSERT(r == static_cast<int>(m_var_data.size()));
         m_var_data.push_back(alloc(var_data));
         var_data * d  = m_var_data[r];

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -317,8 +317,7 @@ namespace smt {
         SASSERT(!m_fpa_util.is_fp(e));
         SASSERT(m_bv_util.is_bv(e));
         SASSERT(m_fpa_util.is_float(s) || m_fpa_util.is_rm(s));
-        ast_manager & m = get_manager();
-        sort * bv_srt = m.get_sort(e);
+        ast_manager & m = get_manager();        
         app_ref res(m);
 
         unsigned bv_sz = m_bv_util.get_bv_size(e);

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -54,10 +54,9 @@ namespace smt {
             unsigned bv_sz = m_th.m_bv_util.get_bv_size(bv);
             unsigned sbits = m_th.m_fpa_util.get_sbits(s);
             SASSERT(bv_sz == m_th.m_fpa_util.get_ebits(s) + sbits);
-            m_th.m_converter.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, bv),
-                                   m_bv_util.mk_extract(bv_sz - 2, sbits - 1, bv),
-                                   m_bv_util.mk_extract(sbits - 2, 0, bv),
-                                   result);
+            result = m_util.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, bv),
+                                  m_bv_util.mk_extract(bv_sz - 2, sbits - 1, bv),
+                                  m_bv_util.mk_extract(sbits - 2, 0, bv));
             SASSERT(m_th.m_fpa_util.is_float(result));
             m_const2bv.insert(f, result);
             m.inc_ref(f);
@@ -76,7 +75,7 @@ namespace smt {
             SASSERT(is_rm(f->get_range()));
             expr_ref bv(m);
             bv = m_th.wrap(m.mk_const(f));
-            mk_rm(bv, result);
+            result = m_util.mk_rm(bv);
             m_rm_const2bv.insert(f, result);
             m.inc_ref(f);
             m.inc_ref(result);
@@ -84,8 +83,8 @@ namespace smt {
     }
 
     void theory_fpa::fpa2bv_converter_wrapped::mk_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
-        return fpa2bv_converter::mk_function(f, num, args, result);
-        TRACE("t_fpa", tout << "UF result: " << mk_ismt2_pp(result, m) << std::endl; );
+        // Note: this introduces new UFs that should be filtered afterwards. 
+        return fpa2bv_converter::mk_function(f, num, args, result);        
     }
 
     expr_ref theory_fpa::fpa2bv_converter_wrapped::mk_min_unspecified(func_decl * f, expr * x, expr * y) {
@@ -100,10 +99,9 @@ namespace smt {
         expr_ref a(m), wrapped(m);
         a = m.mk_app(w, x, y);
         wrapped = m_th.wrap(a);
-        m_th.m_converter.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, wrapped),
-                               m_bv_util.mk_extract(bv_sz - 2, sbits - 1, wrapped),
-                               m_bv_util.mk_extract(sbits - 2, 0, wrapped),
-                               res);
+        res = m_util.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, wrapped),
+                           m_bv_util.mk_extract(bv_sz - 2, sbits - 1, wrapped),
+                           m_bv_util.mk_extract(sbits - 2, 0, wrapped));
 
         expr_ref sc(m);
         m_th.m_converter.mk_is_zero(res, sc);
@@ -123,10 +121,9 @@ namespace smt {
         expr_ref a(m), wrapped(m);
         a = m.mk_app(w, x, y);
         wrapped = m_th.wrap(a);
-        m_th.m_converter.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, wrapped),
-                               m_bv_util.mk_extract(bv_sz - 2, sbits - 1, wrapped),
-                               m_bv_util.mk_extract(sbits - 2, 0, wrapped),
-                               res);
+        res = m_util.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, wrapped),
+                           m_bv_util.mk_extract(bv_sz - 2, sbits - 1, wrapped),
+                           m_bv_util.mk_extract(sbits - 2, 0, wrapped));
 
         expr_ref sc(m);
         m_th.m_converter.mk_is_zero(res, sc);
@@ -380,7 +377,7 @@ namespace smt {
             SASSERT(m_fpa_util.is_rm_bvwrap(e_conv));
             expr_ref bv_rm(m);
             m_th_rw(to_app(e_conv)->get_arg(0), bv_rm);
-            m_converter.mk_rm(bv_rm, res);
+            res = m_fpa_util.mk_rm(bv_rm);
         }
         else if (m_fpa_util.is_float(e)) {
             SASSERT(m_fpa_util.is_fp(e_conv));
@@ -389,7 +386,7 @@ namespace smt {
             m_th_rw(sgn);
             m_th_rw(exp);
             m_th_rw(sig);
-            m_converter.mk_fp(sgn, exp, sig, res);
+            res = m_fpa_util.mk_fp(sgn, exp, sig);
         }
         else
             UNREACHABLE();

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -85,8 +85,63 @@ namespace smt {
     }
 
     void theory_fpa::fpa2bv_converter_wrapped::mk_uninterpreted_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result) {
-        // TODO: This introduces temporary variables/func_decls that should be filtered in the end.
-        fpa2bv_converter::mk_uninterpreted_function(f, num, args, result);
+        // TODO: This introduces temporary func_decls that should be filtered in the end.
+
+        TRACE("t_fpa", tout << "UF: " << mk_ismt2_pp(f, m) << std::endl; );
+        SASSERT(f->get_arity() == num);
+        
+        expr_ref_buffer new_args(m);
+
+        for (unsigned i = 0; i < num; i++) {
+            if (is_float(args[i]) || is_rm(args[i])) {
+                expr_ref ai(m), wrapped(m);
+                ai = args[i];                
+                wrapped = m_th.wrap(ai);
+                new_args.push_back(wrapped);
+                m_extra_assertions.push_back(m.mk_eq(m_th.unwrap(wrapped, m.get_sort(ai)), ai));
+            }
+            else
+                new_args.push_back(args[i]);
+        }
+
+        func_decl * fd;
+        if (m_uf2bvuf.find(f, fd))
+            mk_uninterpreted_output(f->get_range(), fd, new_args, result);
+        else {
+            sort_ref_buffer new_domain(m);
+
+            for (unsigned i = 0; i < f->get_arity(); i++) {
+                sort * di = f->get_domain()[i];
+                if (is_float(di))
+                    new_domain.push_back(m_bv_util.mk_sort(m_util.get_sbits(di) + m_util.get_ebits(di)));
+                else if (is_rm(di))
+                    new_domain.push_back(m_bv_util.mk_sort(3));
+                else
+                    new_domain.push_back(di);
+            }
+
+            sort * frng = f->get_range();
+            sort_ref rng(frng, m);
+            if (m_util.is_float(frng))
+                rng = m_bv_util.mk_sort(m_util.get_ebits(frng) + m_util.get_sbits(frng));
+            else if (m_util.is_rm(frng))
+                rng = m_bv_util.mk_sort(3);
+
+            func_decl_ref fbv(m);
+            fbv = m.mk_fresh_func_decl(new_domain.size(), new_domain.c_ptr(), rng);            
+            TRACE("t_fpa", tout << "New UF func_decl : " << mk_ismt2_pp(fbv, m) << std::endl;);
+
+            m_uf2bvuf.insert(f, fbv);
+            m.inc_ref(f);
+            m.inc_ref(fbv);
+
+            mk_uninterpreted_output(frng, fbv, new_args, result);
+        }
+
+        expr_ref fapp(m);
+        fapp = m.mk_app(f, num, args);
+        m_extra_assertions.push_back(m.mk_eq(fapp, result));        
+        TRACE("t_fpa", tout << "UF result: " << mk_ismt2_pp(result, m) << std::endl; );
     }
 
     expr_ref theory_fpa::fpa2bv_converter_wrapped::mk_min_unspecified(func_decl * f, expr * x, expr * y) {
@@ -284,30 +339,40 @@ namespace smt {
     app_ref theory_fpa::wrap(expr * e) {
         SASSERT(!m_fpa_util.is_wrap(e));
         ast_manager & m = get_manager();
-        sort * e_srt = m.get_sort(e);
+        app_ref res(m);
 
-        func_decl *w;
+        if (is_app(e) &&
+            to_app(e)->get_family_id() == get_family_id() &&
+            to_app(e)->get_decl_kind() == OP_FPA_FP) {
+            expr * cargs[3] = { to_app(e)->get_arg(0), to_app(e)->get_arg(1), to_app(e)->get_arg(2) };            
+            res = m_bv_util.mk_concat(3, cargs);
+            m_th_rw((expr_ref&)res);
+        }
+        else {
+            sort * e_srt = m.get_sort(e);
+            func_decl * w;
 
-        if (!m_wraps.find(e_srt, w)) {
-            SASSERT(!m_wraps.contains(e_srt));
+            if (!m_wraps.find(e_srt, w)) {
+                SASSERT(!m_wraps.contains(e_srt));
 
-            sort * bv_srt;
-            if (m_converter.is_rm(e_srt))
-                bv_srt = m_bv_util.mk_sort(3);
-            else {
-                SASSERT(m_converter.is_float(e_srt));
-                unsigned ebits = m_fpa_util.get_ebits(e_srt);
-                unsigned sbits = m_fpa_util.get_sbits(e_srt);
-                bv_srt = m_bv_util.mk_sort(ebits + sbits);
+                sort * bv_srt;
+                if (m_converter.is_rm(e_srt))
+                    bv_srt = m_bv_util.mk_sort(3);
+                else {
+                    SASSERT(m_converter.is_float(e_srt));
+                    unsigned ebits = m_fpa_util.get_ebits(e_srt);
+                    unsigned sbits = m_fpa_util.get_sbits(e_srt);
+                    bv_srt = m_bv_util.mk_sort(ebits + sbits);
+                }
+
+                w = m.mk_func_decl(get_family_id(), OP_FPA_INTERNAL_BVWRAP, 0, 0, 1, &e_srt, bv_srt);
+                m_wraps.insert(e_srt, w);
+                m.inc_ref(w);
             }
 
-            w = m.mk_func_decl(get_family_id(), OP_FPA_INTERNAL_BVWRAP, 0, 0, 1, &e_srt, bv_srt);
-            m_wraps.insert(e_srt, w);
-            m.inc_ref(w);
+            res = m.mk_app(w, e);
         }
-
-        app_ref res(m);
-        res = m.mk_app(w, e);
+        
         return res;
     }
 
@@ -388,59 +453,6 @@ namespace smt {
         SASSERT(res.get() != 0);
         return res;
     }
-
-#if 0
-    expr_ref theory_fpa::convert_uf(expr * e) {
-        SASSERT(is_app(e));
-        ast_manager & m = get_manager();
-        expr_ref res(m);
-
-        app * a = to_app(e);
-        func_decl * f = a->get_decl();
-        sort * const * domain = f->get_domain();
-        unsigned arity = f->get_arity();
-
-        expr_ref_buffer new_args(m);
-        expr_ref unwrapped(m);
-
-        for (unsigned i = 0; i < arity; i++) {
-            expr * ai = a->get_arg(i);
-            if (m_fpa_util.is_float(ai) || m_fpa_util.is_rm(ai)) {
-                if (m_fpa_util.is_unwrap(ai))
-                    unwrapped = ai;
-                else {
-                    // unwrapped = unwrap(wrap(ai), domain[i]);
-                    // assert_cnstr(m.mk_eq(unwrapped, ai));
-                    // assert_cnstr();
-                    unwrapped = convert_term(ai);
-                }
-
-                new_args.push_back(unwrapped);
-                TRACE("t_fpa_detail", tout << "UF arg(" << i << ") = " << mk_ismt2_pp(unwrapped, get_manager()) << "\n";);
-            }
-            else
-                new_args.push_back(ai);
-        }
-
-        sort * rng = f->get_range();
-        if (m_fpa_util.is_float(rng)) {
-            unsigned sbits = m_fpa_util.get_sbits(rng);
-            unsigned bv_sz = m_fpa_util.get_ebits(rng) + sbits;
-            expr_ref wrapped(m);
-            wrapped = wrap(m.mk_app(f, new_args.size(), new_args.c_ptr()));
-
-            m_converter.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, wrapped),
-                              m_bv_util.mk_extract(bv_sz - 2, sbits - 1, wrapped),
-                              m_bv_util.mk_extract(sbits - 2, 0, wrapped),
-                              res);
-        }
-        else
-            res = m.mk_app(f, new_args.size(), new_args.c_ptr());
-
-        TRACE("t_fpa_detail", tout << "UF call = " << mk_ismt2_pp(res, get_manager()) << "\n";);
-        return res;
-    }
-#endif
 
     expr_ref theory_fpa::convert_conversion_term(expr * e) {
         /* This is for the conversion functions fp.to_* */
@@ -606,6 +618,7 @@ namespace smt {
         // Therefore, we translate and assert them here.
         fpa_op_kind k = (fpa_op_kind)term->get_decl_kind();
         switch (k) {
+        case OP_FPA_TO_FP:
         case OP_FPA_TO_UBV:
         case OP_FPA_TO_SBV:
         case OP_FPA_TO_REAL:
@@ -965,5 +978,17 @@ namespace smt {
             expr * r = (*it)->get_root()->get_owner();
             out << r->get_id() << " --> " << mk_ismt2_pp(n, m) << std::endl;
         }
+    }
+
+    bool theory_fpa::include_func_interp(func_decl * f) {
+        TRACE("t_fpa", tout << "f = " << mk_ismt2_pp(f, get_manager()) << std::endl;);
+        func_decl * wt;
+
+        if (m_wraps.find(f->get_range(), wt) || m_unwraps.find(f->get_range(), wt))
+            return wt == f;
+        else if (m_converter.is_uf2bvuf(f) || m_converter.is_special(f))
+            return false;
+        else
+            return true;
     }
 };

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -276,6 +276,7 @@ namespace smt {
             SASSERT(r && bv_sz == m_ebits);
             r = m_bu.is_numeral(values[2], sig_r, bv_sz);
             SASSERT(r && bv_sz == m_sbits - 1);
+            (void)r;
 
             SASSERT(mpzm.is_one(sgn_r.to_mpq().denominator()));
             SASSERT(mpzm.is_one(exp_r.to_mpq().denominator()));

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -88,8 +88,6 @@ namespace smt {
     }
 
     expr_ref theory_fpa::fpa2bv_converter_wrapped::mk_min_max_unspecified(func_decl * f, expr * x, expr * y) {
-        unsigned ebits = m_util.get_ebits(f->get_range());
-        unsigned sbits = m_util.get_sbits(f->get_range());
 
         expr_ref a(m), wrapped(m), wu(m), wu_eq(m);
         a = m.mk_app(f, x, y);

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -52,9 +52,8 @@ namespace smt {
             expr_ref bv(m);
             bv = m_th.wrap(m.mk_const(f));
             unsigned bv_sz = m_th.m_bv_util.get_bv_size(bv);
-            unsigned ebits = m_th.m_fpa_util.get_ebits(s);
             unsigned sbits = m_th.m_fpa_util.get_sbits(s);
-            SASSERT(bv_sz == ebits + sbits);
+            SASSERT(bv_sz == m_th.m_fpa_util.get_ebits(s) + sbits);
             m_th.m_converter.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, bv),
                                    m_bv_util.mk_extract(bv_sz - 2, sbits - 1, bv),
                                    m_bv_util.mk_extract(sbits - 2, 0, bv),
@@ -231,10 +230,11 @@ namespace smt {
     }
 
     app * theory_fpa::fpa_value_proc::mk_value(model_generator & mg, ptr_vector<expr> & values) {
-        ast_manager & m = m_th.get_manager();
 
-        TRACE("t_fpa_detail", for (unsigned i = 0; i < values.size(); i++)
-                                  tout << "value[" << i << "] = " << mk_ismt2_pp(values[i], m) << std::endl;);
+        TRACE("t_fpa_detail", 
+              ast_manager & m = m_th.get_manager();
+              for (unsigned i = 0; i < values.size(); i++)
+                  tout << "value[" << i << "] = " << mk_ismt2_pp(values[i], m) << std::endl;);
 
         mpf_manager & mpfm = m_fu.fm();
         unsynch_mpz_manager & mpzm = mpfm.mpz_manager();
@@ -254,8 +254,7 @@ namespace smt {
             rational all_r(0);
             scoped_mpz all_z(mpzm);
 
-            bool r = m_bu.is_numeral(values[0], all_r, bv_sz);
-            SASSERT(r);
+            VERIFY(m_bu.is_numeral(values[0], all_r, bv_sz));
             SASSERT(bv_sz == (m_ebits + m_sbits));
             SASSERT(all_r.is_int());
             mpzm.set(all_z, all_r.to_mpq().numerator());
@@ -316,8 +315,7 @@ namespace smt {
         unsigned bv_sz;
 
         rational val(0);
-        bool r = m_bu.is_numeral(values[0], val, bv_sz);
-        SASSERT(r);
+        VERIFY(m_bu.is_numeral(values[0], val, bv_sz));
         SASSERT(bv_sz == 3);
 
         switch (val.get_uint64())
@@ -422,9 +420,8 @@ namespace smt {
                 expr_ref bv(m);
                 bv = wrap(e_conv);
                 unsigned bv_sz = m_bv_util.get_bv_size(bv);
-                unsigned ebits = m_fpa_util.get_ebits(m.get_sort(e_conv));
                 unsigned sbits = m_fpa_util.get_sbits(m.get_sort(e_conv));
-                SASSERT(bv_sz == ebits + sbits);
+                SASSERT(bv_sz == m_fpa_util.get_ebits(m.get_sort(e_conv)) + sbits);
                 m_converter.mk_fp(m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, bv),
                     m_bv_util.mk_extract(bv_sz - 2, sbits - 1, bv),
                     m_bv_util.mk_extract(sbits - 2, 0, bv),

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -306,9 +306,10 @@ namespace smt {
 
     app * theory_fpa::fpa_rm_value_proc::mk_value(model_generator & mg, ptr_vector<expr> & values) {
         SASSERT(values.size() == 1);
-        ast_manager & m = m_th.get_manager();
 
-        TRACE("t_fpa_detail", for (unsigned i = 0; i < values.size(); i++)
+        TRACE("t_fpa_detail", 
+              ast_manager & m = m_th.get_manager();
+              for (unsigned i = 0; i < values.size(); i++)
               tout << "value[" << i << "] = " << mk_ismt2_pp(values[i], m) << std::endl;);
 
         app * result = 0;

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -90,7 +90,6 @@ namespace smt {
     expr_ref theory_fpa::fpa2bv_converter_wrapped::mk_min_max_unspecified(func_decl * f, expr * x, expr * y) {
         unsigned ebits = m_util.get_ebits(f->get_range());
         unsigned sbits = m_util.get_sbits(f->get_range());
-        unsigned bv_sz = ebits + sbits;
 
         expr_ref a(m), wrapped(m), wu(m), wu_eq(m);
         a = m.mk_app(f, x, y);

--- a/src/smt/theory_fpa.h
+++ b/src/smt/theory_fpa.h
@@ -83,7 +83,7 @@ namespace smt {
             virtual ~fpa2bv_converter_wrapped() {}
             virtual void mk_const(func_decl * f, expr_ref & result);
             virtual void mk_rm_const(func_decl * f, expr_ref & result);
-            virtual void mk_uninterpreted_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);
+            virtual void mk_uninterpreted_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);            
 
             virtual expr_ref mk_min_unspecified(func_decl * f, expr * x, expr * y);
             virtual expr_ref mk_max_unspecified(func_decl * f, expr * x, expr * y);
@@ -112,7 +112,7 @@ namespace smt {
                 result.append(m_deps);
             }
 
-            virtual app * mk_value(model_generator & mg, ptr_vector<expr> & values);
+            virtual app * mk_value(model_generator & mg, ptr_vector<expr> & values);            
         };
 
         class fpa_rm_value_proc : public model_value_proc {
@@ -163,6 +163,7 @@ namespace smt {
         virtual char const * get_name() const { return "fpa"; }
 
         virtual model_value_proc * mk_value(enode * n, model_generator & mg);
+        virtual bool include_func_interp(func_decl * f);
 
         void assign_eh(bool_var v, bool is_true);
         virtual void relevant_eh(app * n);

--- a/src/smt/theory_fpa.h
+++ b/src/smt/theory_fpa.h
@@ -144,8 +144,7 @@ namespace smt {
         fpa_util                & m_fpa_util;
         bv_util                 & m_bv_util;
         arith_util              & m_arith_util;
-        obj_map<sort, func_decl*> m_wraps;
-        obj_map<sort, func_decl*> m_unwraps;
+        obj_map<sort, func_decl*> m_wraps;        
         obj_map<expr, expr*>      m_conversions;
         bool                      m_is_initialized;
         obj_hashtable<func_decl>  m_is_added_to_model;

--- a/src/smt/theory_fpa.h
+++ b/src/smt/theory_fpa.h
@@ -82,9 +82,8 @@ namespace smt {
                 m_th(*th) {}
             virtual ~fpa2bv_converter_wrapped() {}
             virtual void mk_const(func_decl * f, expr_ref & result);
-            virtual void mk_rm_const(func_decl * f, expr_ref & result);
-            void mk_uninterpreted_output(sort * rng, func_decl * fbv, expr_ref_buffer & new_args, expr_ref & result);
-            virtual void mk_uninterpreted_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);            
+            virtual void mk_rm_const(func_decl * f, expr_ref & result);            
+            virtual void mk_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);            
 
             virtual expr_ref mk_min_unspecified(func_decl * f, expr * x, expr * y);
             virtual expr_ref mk_max_unspecified(func_decl * f, expr * x, expr * y);

--- a/src/smt/theory_fpa.h
+++ b/src/smt/theory_fpa.h
@@ -85,8 +85,7 @@ namespace smt {
             virtual void mk_rm_const(func_decl * f, expr_ref & result);            
             virtual void mk_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);            
 
-            virtual expr_ref mk_min_unspecified(func_decl * f, expr * x, expr * y);
-            virtual expr_ref mk_max_unspecified(func_decl * f, expr * x, expr * y);
+            virtual expr_ref mk_min_max_unspecified(func_decl * f, expr * x, expr * y);
         };
 
         class fpa_value_proc : public model_value_proc {
@@ -149,6 +148,7 @@ namespace smt {
         obj_map<sort, func_decl*> m_unwraps;
         obj_map<expr, expr*>      m_conversions;
         bool                      m_is_initialized;
+        obj_hashtable<func_decl>  m_is_added_to_model;
 
         virtual final_check_status final_check_eh();
         virtual bool internalize_atom(app * atom, bool gate_ctx);

--- a/src/smt/theory_fpa.h
+++ b/src/smt/theory_fpa.h
@@ -83,6 +83,7 @@ namespace smt {
             virtual ~fpa2bv_converter_wrapped() {}
             virtual void mk_const(func_decl * f, expr_ref & result);
             virtual void mk_rm_const(func_decl * f, expr_ref & result);
+            void mk_uninterpreted_output(sort * rng, func_decl * fbv, expr_ref_buffer & new_args, expr_ref & result);
             virtual void mk_uninterpreted_function(func_decl * f, unsigned num, expr * const * args, expr_ref & result);            
 
             virtual expr_ref mk_min_unspecified(func_decl * f, expr * x, expr * y);

--- a/src/smt/theory_pb.cpp
+++ b/src/smt/theory_pb.cpp
@@ -1063,7 +1063,7 @@ namespace smt {
         }
 #endif
         else {
-            IF_VERBOSE(3, display(verbose_stream() << "no propagation ", c, true););
+            IF_VERBOSE(14, display(verbose_stream() << "no propagation ", c, true););
         }
     }
 
@@ -1637,7 +1637,7 @@ namespace smt {
                 // same order as the assignment stack.
                 // It is not a correctness bug but causes to miss lemmas.
                 //
-                IF_VERBOSE(2, display_resolved_lemma(verbose_stream()););
+                IF_VERBOSE(12, display_resolved_lemma(verbose_stream()););
                 TRACE("pb", display_resolved_lemma(tout););
                 return false;
             }
@@ -1735,12 +1735,12 @@ namespace smt {
         // 3x + 3y + z + u >= 4
         // ~x /\ ~y => z + u >= 
 
-        IF_VERBOSE(4, display(verbose_stream() << "lemma1: ", m_lemma););
+        IF_VERBOSE(14, display(verbose_stream() << "lemma1: ", m_lemma););
         hoist_maximal_values();
         lbool is_true = m_lemma.normalize(false);
         m_lemma.prune(false);
 
-        IF_VERBOSE(4, display(verbose_stream() << "lemma2: ", m_lemma););
+        IF_VERBOSE(14, display(verbose_stream() << "lemma2: ", m_lemma););
         //unsigned l_size = m_ineq_literals.size() + ((is_true==l_false)?0:m_lemma.size());
         //if (s_min_l_size >= l_size) {
         //    verbose_stream() << "(pb.conflict min size: " << l_size << ")\n";

--- a/src/smt/theory_pb.cpp
+++ b/src/smt/theory_pb.cpp
@@ -787,8 +787,7 @@ namespace smt {
             }
 
             for (unsigned i = 0; i < ineqs->size(); ++i) {
-                ineq* c = (*ineqs)[i]; 
-                SASSERT(c->is_ge());
+                SASSERT((*ineqs)[i]->is_ge());
                 if (assign_watch_ge(v, is_true, *ineqs, i)) {
                     // i was removed from watch list.
                     --i;
@@ -1834,13 +1833,12 @@ namespace smt {
 
     void theory_pb::validate_assign(ineq const& c, literal_vector const& lits, literal l) const {
         uint_set nlits;
-        context& ctx = get_context();
         for (unsigned i = 0; i < lits.size(); ++i) {
-            SASSERT(ctx.get_assignment(lits[i]) == l_true);
+            SASSERT(get_context().get_assignment(lits[i]) == l_true);
             nlits.insert((~lits[i]).index());
         }
-        SASSERT(ctx.get_assignment(l) == l_undef);
-        SASSERT(ctx.get_assignment(c.lit()) == l_true);
+        SASSERT(get_context().get_assignment(l) == l_undef);
+        SASSERT(get_context().get_assignment(c.lit()) == l_true);
         nlits.insert(l.index());
         numeral sum = numeral::zero();
         for (unsigned i = 0; i < c.size(); ++i) {

--- a/src/smt/theory_seq.cpp
+++ b/src/smt/theory_seq.cpp
@@ -2380,7 +2380,7 @@ void theory_seq::init_model(expr_ref_vector const& es) {
 }
 
 void theory_seq::init_model(model_generator & mg) {
-    m_factory = alloc(seq_factory, get_manager(), get_family_id());
+    m_factory = alloc(seq_factory, get_manager(), get_family_id(), mg.get_model());
     mg.register_factory(m_factory);
     for (unsigned j = 0; j < m_nqs.size(); ++j) {
         ne const& n = m_nqs[j];
@@ -2469,7 +2469,9 @@ model_value_proc * theory_seq::mk_value(enode * n, model_generator & mg) {
         for (unsigned i = 0; i < concats.size(); ++i) {
             expr* c = concats[i], *c1;
             if (m_util.str.is_unit(c, c1)) {
-                sv->add_dependency(ctx.get_enode(c1));
+                if (ctx.e_internalized(c1)) {
+                    sv->add_dependency(ctx.get_enode(c1));
+                }
             }
             else if (m_util.str.is_string(c)) {
                 sv->add_string(c);

--- a/src/smt/theory_seq.cpp
+++ b/src/smt/theory_seq.cpp
@@ -3741,7 +3741,6 @@ expr_ref theory_seq::mk_step(expr* s, expr* idx, expr* re, unsigned i, unsigned 
    rej(s, idx, re, i) -> len(s) > idx     if i is final
 */
 void theory_seq::propagate_acc_rej_length(literal lit, expr* e) {
-    context& ctx = get_context();
     expr *s, * idx, *re;
     unsigned src;
     eautomaton* aut = 0;
@@ -3752,7 +3751,7 @@ void theory_seq::propagate_acc_rej_length(literal lit, expr* e) {
     }
     if (m_util.str.is_length(idx)) return;
     SASSERT(m_autil.is_numeral(idx));
-    SASSERT(ctx.get_assignment(lit) == l_true);
+    SASSERT(get_context().get_assignment(lit) == l_true);
     bool is_final = aut->is_final_state(src);
     if (is_final == is_acc) {
         propagate_lit(0, 1, &lit, mk_literal(m_autil.mk_ge(m_util.str.mk_length(s), idx)));

--- a/src/smt/theory_seq.cpp
+++ b/src/smt/theory_seq.cpp
@@ -3244,8 +3244,7 @@ void theory_seq::add_at_axiom(expr* e) {
    step(s, idx, re, i, j, t) -> nth(s, idx) == t & len(s) > idx
 */
 void theory_seq::propagate_step(literal lit, expr* step) {
-    context& ctx = get_context();
-    SASSERT(ctx.get_assignment(lit) == l_true);
+    SASSERT(get_context().get_assignment(lit) == l_true);
     expr* re, *acc, *s, *idx, *i, *j;
     VERIFY(is_step(step, s, idx, re, i, j, acc));
     TRACE("seq", tout << mk_pp(step, m) << " -> " << mk_pp(acc, m) << "\n";);
@@ -3265,9 +3264,8 @@ void theory_seq::propagate_step(literal lit, expr* step) {
     lit => s = (nth s 0) ++ (nth s 1) ++ ... ++ (nth s idx) ++ (tail s idx)
 */
 void theory_seq::ensure_nth(literal lit, expr* s, expr* idx) {
-    context& ctx = get_context();
     rational r;
-    SASSERT(ctx.get_assignment(lit) == l_true);
+    SASSERT(get_context().get_assignment(lit) == l_true);
     VERIFY(m_autil.is_numeral(idx, r) && r.is_unsigned());
     unsigned _idx = r.get_unsigned();
     expr_ref head(m), tail(m), conc(m), len1(m), len2(m);

--- a/src/smt/theory_seq.cpp
+++ b/src/smt/theory_seq.cpp
@@ -2823,6 +2823,7 @@ void theory_seq::add_elim_string_axiom(expr* n) {
     - len(unit(u)) = 1              if x = unit(u)
     - len(str) = str.length()       if x = str
     - len(empty) = 0                if x = empty
+    - len(int.to.str(i)) >= 1       if x = int.to.str(i) and more generally if i = 0 then 1 else 1+floor(log(|i|))
     - len(x) >= 0                   otherwise
  */
 void theory_seq::add_length_axiom(expr* n) {
@@ -2837,16 +2838,17 @@ void theory_seq::add_length_axiom(expr* n) {
         m_rewrite(len);
         SASSERT(n != len);
         add_axiom(mk_eq(len, n, false));
-        if (!ctx.at_base_level()) {
-            m_trail_stack.push(push_replay(alloc(replay_axiom, m, n)));
-        }
+    }
+    else if (m_util.str.is_itos(x)) {
+        add_axiom(mk_literal(m_autil.mk_ge(n, m_autil.mk_int(1))));
     }
     else {
         add_axiom(mk_literal(m_autil.mk_ge(n, m_autil.mk_int(0))));
-        if (!ctx.at_base_level()) {
-            m_trail_stack.push(push_replay(alloc(replay_axiom, m, n)));
-        }
     }
+    if (!ctx.at_base_level()) {
+        m_trail_stack.push(push_replay(alloc(replay_axiom, m, n)));
+    }
+
 }
 
 

--- a/src/smt/theory_seq.h
+++ b/src/smt/theory_seq.h
@@ -410,6 +410,7 @@ namespace smt {
         bool solve_nqs(unsigned i);
         bool solve_ne(unsigned i);
         bool solve_nc(unsigned i);
+        void reduce_ite(expr_ref_vector& ls, literal_vector& new_lits, unsigned& num_undef_lits, bool& change);
 
         struct cell {
             cell*       m_parent;

--- a/src/smt/theory_seq.h
+++ b/src/smt/theory_seq.h
@@ -410,7 +410,6 @@ namespace smt {
         bool solve_nqs(unsigned i);
         bool solve_ne(unsigned i);
         bool solve_nc(unsigned i);
-        void reduce_ite(expr_ref_vector& ls, literal_vector& new_lits, unsigned& num_undef_lits, bool& change);
 
         struct cell {
             cell*       m_parent;

--- a/src/smt/theory_wmaxsat.cpp
+++ b/src/smt/theory_wmaxsat.cpp
@@ -260,7 +260,6 @@ void theory_wmaxsat::block() {
         return;
     }
     ++m_stats.m_num_blocks;
-    ast_manager& m = get_manager();
     context& ctx = get_context();
     literal_vector lits;
     compare_cost compare_cost(*this);
@@ -274,6 +273,7 @@ void theory_wmaxsat::block() {
         lits.push_back(~literal(m_var2bool[costs[i]]));
     }
     TRACE("opt",
+          ast_manager& m = get_manager();
           tout << "block: ";
           for (unsigned i = 0; i < lits.size(); ++i) {
               expr_ref tmp(m);

--- a/src/solver/solver_na2as.cpp
+++ b/src/solver/solver_na2as.cpp
@@ -71,12 +71,14 @@ void solver_na2as::push() {
 }
 
 void solver_na2as::pop(unsigned n) {
-    pop_core(n);
-    unsigned lvl = m_scopes.size();
-    SASSERT(n <= lvl);
-    unsigned new_lvl = lvl - n;
-    restore_assumptions(m_scopes[new_lvl]);
-    m_scopes.shrink(new_lvl);
+    if (n > 0) {
+        pop_core(n);
+        unsigned lvl = m_scopes.size();
+        SASSERT(n <= lvl);
+        unsigned new_lvl = lvl - n;
+        restore_assumptions(m_scopes[new_lvl]);
+        m_scopes.shrink(new_lvl);
+    }
 }
 
 void solver_na2as::restore_assumptions(unsigned old_sz) {

--- a/src/tactic/arith/fm_tactic.cpp
+++ b/src/tactic/arith/fm_tactic.cpp
@@ -156,6 +156,7 @@ class fm_tactic : public tactic {
                     r = c;
                 }
             }
+            (void)found;
             SASSERT(found);
             return is_lower ? LOWER : UPPER;
         }

--- a/src/tactic/arith/lia2card_tactic.cpp
+++ b/src/tactic/arith/lia2card_tactic.cpp
@@ -300,6 +300,7 @@ public:
     bool get_sum(expr* x, rational const& mul, expr_ref_vector& conds, expr_ref_vector& args, vector<rational>& coeffs, rational& coeff) {
         expr *y, *z, *u;
         rational r, q;
+		if (!is_app(x)) return false;
         app* f = to_app(x);
         bool ok = true;
         if (a.is_add(x)) {

--- a/src/tactic/arith/lia2card_tactic.cpp
+++ b/src/tactic/arith/lia2card_tactic.cpp
@@ -300,7 +300,7 @@ public:
     bool get_sum(expr* x, rational const& mul, expr_ref_vector& conds, expr_ref_vector& args, vector<rational>& coeffs, rational& coeff) {
         expr *y, *z, *u;
         rational r, q;
-		if (!is_app(x)) return false;
+        if (!is_app(x)) return false;
         app* f = to_app(x);
         bool ok = true;
         if (a.is_add(x)) {

--- a/src/tactic/fpa/fpa2bv_model_converter.cpp
+++ b/src/tactic/fpa/fpa2bv_model_converter.cpp
@@ -412,7 +412,7 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
                 // Just keep.
                 expr_ref val(m);
                 bv_mdl->eval(it->m_value, val);
-                float_mdl->register_decl(f, val);
+                if (val) float_mdl->register_decl(f, val);
             }
         }            
         else {

--- a/src/tactic/fpa/fpa2bv_model_converter.cpp
+++ b/src/tactic/fpa/fpa2bv_model_converter.cpp
@@ -17,6 +17,7 @@ Notes:
 
 --*/
 #include"ast_smt2_pp.h"
+#include"fpa_rewriter.h"
 #include"fpa2bv_model_converter.h"
 
 void fpa2bv_model_converter::display(std::ostream & out) {
@@ -101,17 +102,15 @@ model_converter * fpa2bv_model_converter::translate(ast_translation & translator
     return res;
 }
 
-expr_ref fpa2bv_model_converter::convert_bv2fp(sort * s, expr * sgn, expr * exp, expr * sig) const {
-    fpa_util fu(m);
-    bv_util bu(m);
-    unsynch_mpz_manager & mpzm = fu.fm().mpz_manager();
-    unsynch_mpq_manager & mpqm = fu.fm().mpq_manager();
+expr_ref fpa2bv_model_converter::convert_bv2fp(sort * s, expr * sgn, expr * exp, expr * sig) {
+    unsynch_mpz_manager & mpzm = m_fpa_util.fm().mpz_manager();
+    unsynch_mpq_manager & mpqm = m_fpa_util.fm().mpq_manager();
 
     expr_ref res(m);
     mpf fp_val;
 
-    unsigned ebits = fu.get_ebits(s);
-    unsigned sbits = fu.get_sbits(s);
+    unsigned ebits = m_fpa_util.get_ebits(s);
+    unsigned sbits = m_fpa_util.get_sbits(s);
 
     unsigned sgn_sz = 1;
     unsigned exp_sz = ebits;
@@ -119,47 +118,44 @@ expr_ref fpa2bv_model_converter::convert_bv2fp(sort * s, expr * sgn, expr * exp,
 
     rational sgn_q(0), sig_q(0), exp_q(0);
 
-    if (sgn) bu.is_numeral(sgn, sgn_q, sgn_sz);
-    if (exp) bu.is_numeral(exp, exp_q, exp_sz);
-    if (sig) bu.is_numeral(sig, sig_q, sig_sz);
+    if (sgn) m_bv_util.is_numeral(sgn, sgn_q, sgn_sz);
+    if (exp) m_bv_util.is_numeral(exp, exp_q, exp_sz);
+    if (sig) m_bv_util.is_numeral(sig, sig_q, sig_sz);
 
     // un-bias exponent
     rational exp_unbiased_q;
-    exp_unbiased_q = exp_q - fu.fm().m_powers2.m1(ebits - 1);
+    exp_unbiased_q = exp_q - m_fpa_util.fm().m_powers2.m1(ebits - 1);
 
     mpz sig_z; mpf_exp_t exp_z;
     mpzm.set(sig_z, sig_q.to_mpq().numerator());
     exp_z = mpzm.get_int64(exp_unbiased_q.to_mpq().numerator());
 
-    fu.fm().set(fp_val, ebits, sbits, !mpqm.is_zero(sgn_q.to_mpq()), exp_z, sig_z);
+    m_fpa_util.fm().set(fp_val, ebits, sbits, !mpqm.is_zero(sgn_q.to_mpq()), exp_z, sig_z);
 
     mpzm.del(sig_z);
 
-    res = fu.mk_value(fp_val);
+    res = m_fpa_util.mk_value(fp_val);
 
     TRACE("fpa2bv_mc", tout << "[" << mk_ismt2_pp(sgn, m) <<
                                " " << mk_ismt2_pp(exp, m) <<
                                " " << mk_ismt2_pp(sig, m) << "] == " <<
                                mk_ismt2_pp(res, m) << std::endl;);
-    fu.fm().del(fp_val);
+    m_fpa_util.fm().del(fp_val);
 
     return res;
 }
 
-expr_ref fpa2bv_model_converter::convert_bv2fp(model * bv_mdl, sort * s, expr * bv) const {
-    fpa_util fu(m);
-    bv_util bu(m);
+expr_ref fpa2bv_model_converter::convert_bv2fp(model * bv_mdl, sort * s, expr * bv) {
+    SASSERT(m_bv_util.is_bv(bv));
 
-    SASSERT(bu.is_bv(bv));
-
-    unsigned ebits = fu.get_ebits(s);
-    unsigned sbits = fu.get_sbits(s);
+    unsigned ebits = m_fpa_util.get_ebits(s);
+    unsigned sbits = m_fpa_util.get_sbits(s);
     unsigned bv_sz = sbits + ebits;
 
     expr_ref sgn(m), exp(m), sig(m);
-    sgn = bu.mk_extract(bv_sz - 1, bv_sz - 1, bv);
-    exp = bu.mk_extract(bv_sz - 2, sbits - 1, bv);
-    sig = bu.mk_extract(sbits - 2, 0, bv);
+    sgn = m_bv_util.mk_extract(bv_sz - 1, bv_sz - 1, bv);
+    exp = m_bv_util.mk_extract(bv_sz - 2, sbits - 1, bv);
+    sig = m_bv_util.mk_extract(sbits - 2, 0, bv);
 
     expr_ref v_sgn(m), v_exp(m), v_sig(m);
     bv_mdl->eval(sgn, v_sgn);
@@ -169,33 +165,28 @@ expr_ref fpa2bv_model_converter::convert_bv2fp(model * bv_mdl, sort * s, expr * 
     return convert_bv2fp(s, v_sgn, v_exp, v_sig);
 }
 
-expr_ref fpa2bv_model_converter::convert_bv2rm(expr * eval_v) const {
-    fpa_util fu(m);
-    bv_util bu(m);
+expr_ref fpa2bv_model_converter::convert_bv2rm(expr * bv_rm) {
     expr_ref res(m);
     rational bv_val(0);
     unsigned sz = 0;
 
-    if (bu.is_numeral(eval_v, bv_val, sz)) {
+    if (m_bv_util.is_numeral(bv_rm, bv_val, sz)) {
         SASSERT(bv_val.is_uint64());
         switch (bv_val.get_uint64()) {
-        case BV_RM_TIES_TO_AWAY: res = fu.mk_round_nearest_ties_to_away(); break;
-        case BV_RM_TIES_TO_EVEN: res = fu.mk_round_nearest_ties_to_even(); break;
-        case BV_RM_TO_NEGATIVE: res = fu.mk_round_toward_negative(); break;
-        case BV_RM_TO_POSITIVE: res = fu.mk_round_toward_positive(); break;
+        case BV_RM_TIES_TO_AWAY: res = m_fpa_util.mk_round_nearest_ties_to_away(); break;
+        case BV_RM_TIES_TO_EVEN: res = m_fpa_util.mk_round_nearest_ties_to_even(); break;
+        case BV_RM_TO_NEGATIVE: res = m_fpa_util.mk_round_toward_negative(); break;
+        case BV_RM_TO_POSITIVE: res = m_fpa_util.mk_round_toward_positive(); break;
         case BV_RM_TO_ZERO:
-        default: res = fu.mk_round_toward_zero();
+        default: res = m_fpa_util.mk_round_toward_zero();
         }
     }
 
     return res;
 }
 
-expr_ref fpa2bv_model_converter::convert_bv2rm(model * bv_mdl, func_decl * var, expr * val) const {
-    fpa_util fu(m);
-    bv_util bu(m);
+expr_ref fpa2bv_model_converter::convert_bv2rm(model * bv_mdl, expr * val) {
     expr_ref res(m);
-
     expr_ref eval_v(m);
 
     if (val && bv_mdl->eval(val, eval_v, true))
@@ -204,10 +195,100 @@ expr_ref fpa2bv_model_converter::convert_bv2rm(model * bv_mdl, func_decl * var, 
     return res;
 }
 
-void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
-    fpa_util fu(m);
-    bv_util bu(m);
+expr_ref fpa2bv_model_converter::rebuild_floats(model * bv_mdl, sort * s, expr * e) {
+    expr_ref result(m);
 
+    TRACE("fpa2bv_mc", tout << "rebuild floats in " << mk_ismt2_pp(s, m) << " for " << mk_ismt2_pp(e, m) << std::endl;);
+
+    if (m_fpa_util.is_float(s)) {
+        SASSERT(m_bv_util.is_bv(e));
+        result = convert_bv2fp(bv_mdl, s, e);
+    }
+    else if (m_fpa_util.is_rm(s)) {
+        SASSERT(m_bv_util.get_bv_size(e) == 3);
+        result = convert_bv2rm(bv_mdl, e);
+    }
+    else if (is_app(e)) {
+        app * a = to_app(e);
+        expr_ref_vector new_args(m);
+        for (unsigned i = 0; i < a->get_num_args(); i++)
+            new_args.push_back(rebuild_floats(bv_mdl, a->get_decl()->get_domain()[i], a->get_arg(i)));
+        result = m.mk_app(a->get_decl(), new_args.size(), new_args.c_ptr());
+    }
+
+    return result;
+}
+
+fpa2bv_model_converter::array_model fpa2bv_model_converter::convert_array_func_interp(func_decl * f, func_decl * bv_f, model * bv_mdl) {
+    SASSERT(f->get_arity() == 0);
+    array_util arr_util(m);
+
+    array_model am(m);
+    sort_ref_vector array_domain(m);    
+    unsigned arity = f->get_range()->get_num_parameters()-1;
+
+    expr_ref as_arr_mdl(m);
+    as_arr_mdl = bv_mdl->get_const_interp(bv_f);
+    TRACE("fpa2bv_mc", tout << "arity=0 func_interp for " << mk_ismt2_pp(f, m) << " := " << mk_ismt2_pp(as_arr_mdl, m) << std::endl;);
+    SASSERT(arr_util.is_as_array(as_arr_mdl));
+    for (unsigned i = 0; i < arity; i++)
+        array_domain.push_back(to_sort(f->get_range()->get_parameter(i).get_ast()));
+    sort * rng = to_sort(f->get_range()->get_parameter(arity).get_ast());
+        
+    bv_f = arr_util.get_as_array_func_decl(to_app(as_arr_mdl));
+
+    am.new_float_fd = m.mk_fresh_func_decl(arity, array_domain.c_ptr(), rng);
+    am.new_float_fi = convert_func_interp(am.new_float_fd, bv_f, bv_mdl);    
+    am.bv_fd = bv_f;
+    am.result = arr_util.mk_as_array(f->get_range(), am.new_float_fd);
+    return am;
+}
+
+func_interp * fpa2bv_model_converter::convert_func_interp(func_decl * f, func_decl * bv_f, model * bv_mdl) {        
+    SASSERT(f->get_arity() > 0);
+    func_interp * result = 0;
+    sort * rng = f->get_range();
+    sort * const * dmn = f->get_domain();     
+
+    unsigned arity = bv_f->get_arity();
+    func_interp * bv_fi = bv_mdl->get_func_interp(bv_f);
+
+    if (bv_fi != 0) {
+        fpa_rewriter rw(m);
+        expr_ref ai(m);
+        result = alloc(func_interp, m, arity);
+
+        for (unsigned i = 0; i < bv_fi->num_entries(); i++) {
+            func_entry const * bv_fe = bv_fi->get_entry(i);
+            expr * const * bv_args = bv_fe->get_args();
+            expr_ref_buffer new_args(m);
+
+            for (unsigned j = 0; j < arity; j++) {
+                sort * ft_dj = dmn[j];
+                expr * bv_aj = bv_args[j];                
+                ai = rebuild_floats(bv_mdl, ft_dj, bv_aj);
+                m_th_rw(ai);
+                new_args.push_back(ai);
+            }
+
+            expr_ref bv_fres(m), ft_fres(m);
+            bv_fres = bv_fe->get_result();
+            ft_fres = rebuild_floats(bv_mdl, rng, bv_fres);
+            m_th_rw(ft_fres);
+            result->insert_new_entry(new_args.c_ptr(), ft_fres);
+        }
+
+        expr_ref bv_els(m), ft_els(m);
+        bv_els = bv_fi->get_else();
+        ft_els = rebuild_floats(bv_mdl, rng, bv_els);
+        m_th_rw(ft_els);
+        result->set_else(ft_els);        
+    }
+
+    return result;
+}
+
+void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
     TRACE("fpa2bv_mc", tout << "BV Model: " << std::endl;
     for (unsigned i = 0; i < bv_mdl->get_num_constants(); i++)
         tout << bv_mdl->get_constant(i)->get_name() << " --> " <<
@@ -233,8 +314,8 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
          it++) {
         func_decl * f = it->m_key;
         expr_ref pzero(m), nzero(m);
-        pzero = fu.mk_pzero(f->get_range());
-        nzero = fu.mk_nzero(f->get_range());
+        pzero = m_fpa_util.mk_pzero(f->get_range());
+        nzero = m_fpa_util.mk_nzero(f->get_range());
 
         expr_ref pn(m), np(m);
         bv_mdl->eval(it->m_value.first, pn, true);
@@ -244,8 +325,8 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
 
         rational pn_num, np_num;
         unsigned bv_sz;
-        bu.is_numeral(pn, pn_num, bv_sz);
-        bu.is_numeral(np, np_num, bv_sz);
+        m_bv_util.is_numeral(pn, pn_num, bv_sz);
+        m_bv_util.is_numeral(np, np_num, bv_sz);
 
         func_interp * flt_fi = alloc(func_interp, m, f->get_arity());
         expr * pn_args[2] = { pzero, nzero };
@@ -263,7 +344,7 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
     {
         func_decl * var = it->m_key;
         app * val = to_app(it->m_value);
-        SASSERT(fu.is_float(var->get_range()));
+        SASSERT(m_fpa_util.is_float(var->get_range()));
         SASSERT(var->get_range()->get_num_parameters() == 2);
 
         expr_ref sgn(m), sig(m), exp(m);
@@ -271,7 +352,7 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
         bv_mdl->eval(val->get_arg(1), exp, true);
         bv_mdl->eval(val->get_arg(2), sig, true);
 
-        SASSERT(val->is_app_of(fu.get_family_id(), OP_FPA_FP));
+        SASSERT(val->is_app_of(m_fpa_util.get_family_id(), OP_FPA_FP));
 
 #ifdef Z3DEBUG
         SASSERT(to_app(val->get_arg(0))->get_decl()->get_arity() == 0);
@@ -301,84 +382,33 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
          it++)
     {
         func_decl * var = it->m_key;
-        SASSERT(fu.is_rm(var->get_range()));
+        SASSERT(m_fpa_util.is_rm(var->get_range()));
         expr * val = it->m_value;
-        SASSERT(is_app_of(val, fu.get_family_id(), OP_FPA_INTERNAL_RM));
+        SASSERT(m_fpa_util.is_rm_bvwrap(val));
         expr * bvval = to_app(val)->get_arg(0);
         expr_ref fv(m);
-        fv = convert_bv2rm(bv_mdl, var, bvval);
+        fv = convert_bv2rm(bv_mdl, bvval);
         TRACE("fpa2bv_mc", tout << var->get_name() << " == " << mk_ismt2_pp(fv, m) << ")" << std::endl;);
         float_mdl->register_decl(var, fv);
         seen.insert(to_app(bvval)->get_decl());
     }
 
     for (obj_map<func_decl, func_decl*>::iterator it = m_uf2bvuf.begin();
-         it != m_uf2bvuf.end();
-         it++) {
+        it != m_uf2bvuf.end();
+        it++) {
         seen.insert(it->m_value);
 
-        func_decl * f = it->m_key;
-        unsigned arity = f->get_arity();
-        sort * rng = f->get_range();
-
-        if (arity > 0) {
-            func_interp * bv_fi = bv_mdl->get_func_interp(it->m_value);            
-
-            if (bv_fi != 0) {
-                func_interp * flt_fi = alloc(func_interp, m, f->get_arity());
-
-                for (unsigned i = 0; i < bv_fi->num_entries(); i++) {
-                    func_entry const * bv_fe = bv_fi->get_entry(i);
-                    expr * const * bv_args = bv_fe->get_args();
-                    expr_ref_buffer new_args(m);
-
-                    for (unsigned j = 0; j < arity; j++) {
-                        sort * dj = f->get_domain(j);
-                        expr * aj = bv_args[j];
-                        expr_ref saj(m);
-                        bv_mdl->eval(aj, saj, true);
-
-                        if (fu.is_float(dj))
-                            new_args.push_back(convert_bv2fp(bv_mdl, dj, saj));
-                        else if (fu.is_rm(dj)) {
-                            expr_ref fv(m);
-                            fv = convert_bv2rm(saj);
-                            new_args.push_back(fv);
-                        }
-                        else
-                            new_args.push_back(saj);                        
-                    }
-
-                    expr_ref ret(m);
-                    ret = bv_fe->get_result();
-                    bv_mdl->eval(ret, ret);
-                    if (fu.is_float(rng))
-                        ret = convert_bv2fp(bv_mdl, rng, ret);
-                    else if (fu.is_rm(rng))
-                        ret = convert_bv2rm(ret);
-
-                    flt_fi->insert_new_entry(new_args.c_ptr(), ret);
-                }
-
-                expr_ref els(m);
-                els = bv_fi->get_else();
-                if (fu.is_float(rng))
-                    els = convert_bv2fp(bv_mdl, rng, els);
-                else if (fu.is_rm(rng))
-                    els = convert_bv2rm(els);
-
-                flt_fi->set_else(els);
-
-                float_mdl->register_decl(f, flt_fi);
-            }
-        }
+        func_decl * f = it->m_key;        
+        if (f->get_arity() == 0)
+        {
+            array_model am = convert_array_func_interp(f, it->m_value, bv_mdl);
+            if (am.new_float_fd) float_mdl->register_decl(am.new_float_fd, am.new_float_fi);
+            if (am.result) float_mdl->register_decl(f, am.result);
+            if (am.bv_fd) seen.insert(am.bv_fd);
+        }            
         else {
-            func_decl * bvf = it->m_value;
-            expr_ref c(m), e(m);
-            c = m.mk_const(bvf);
-            bv_mdl->eval(c, e, true);
-            float_mdl->register_decl(f, e);
-            TRACE("fpa2bv_mc", tout << "model value for " << mk_ismt2_pp(f, m) << " is " << mk_ismt2_pp(e, m) << std::endl;);
+            func_interp * fmv = convert_func_interp(f, it->m_value, bv_mdl);
+            if (fmv) float_mdl->register_decl(f, fmv);
         }
     }
 

--- a/src/tactic/fpa/fpa2bv_model_converter.cpp
+++ b/src/tactic/fpa/fpa2bv_model_converter.cpp
@@ -401,10 +401,19 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
         func_decl * f = it->m_key;        
         if (f->get_arity() == 0)
         {
-            array_model am = convert_array_func_interp(f, it->m_value, bv_mdl);
-            if (am.new_float_fd) float_mdl->register_decl(am.new_float_fd, am.new_float_fi);
-            if (am.result) float_mdl->register_decl(f, am.result);
-            if (am.bv_fd) seen.insert(am.bv_fd);
+            array_util au(m);
+            if (au.is_array(f->get_range())) {
+                array_model am = convert_array_func_interp(f, it->m_value, bv_mdl);
+                if (am.new_float_fd) float_mdl->register_decl(am.new_float_fd, am.new_float_fi);
+                if (am.result) float_mdl->register_decl(f, am.result);
+                if (am.bv_fd) seen.insert(am.bv_fd);
+            }
+            else {
+                // Just keep.
+                expr_ref val(m);
+                bv_mdl->eval(it->m_value, val);
+                float_mdl->register_decl(f, val);
+            }
         }            
         else {
             func_interp * fmv = convert_func_interp(f, it->m_value, bv_mdl);

--- a/src/tactic/fpa/fpa2bv_model_converter.cpp
+++ b/src/tactic/fpa/fpa2bv_model_converter.cpp
@@ -395,7 +395,7 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
         func_decl * var = it->m_key;
         SASSERT(m_fpa_util.is_rm(var->get_range()));
         expr * val = it->m_value;
-        SASSERT(m_fpa_util.is_rm_bvwrap(val));
+        SASSERT(m_fpa_util.is_bv2rm(val));
         expr * bvval = to_app(val)->get_arg(0);
         expr_ref fv(m);
         fv = convert_bv2rm(bv_mdl, bvval);

--- a/src/tactic/fpa/fpa2bv_model_converter.cpp
+++ b/src/tactic/fpa/fpa2bv_model_converter.cpp
@@ -322,50 +322,55 @@ void fpa2bv_model_converter::convert(model * bv_mdl, model * float_mdl) {
         sort * rng = f->get_range();
 
         if (arity > 0) {
-            func_interp * flt_fi = alloc(func_interp, m, f->get_arity());
+            func_interp * bv_fi = bv_mdl->get_func_interp(it->m_value);            
 
-            func_interp * bv_fi = bv_mdl->get_func_interp(it->m_value);
-            SASSERT(bv_fi->args_are_values());
+            if (bv_fi != 0) {
+                func_interp * flt_fi = alloc(func_interp, m, f->get_arity());
 
-            for (unsigned i = 0; i < bv_fi->num_entries(); i++) {
-                func_entry const * bv_fe = bv_fi->get_entry(i);
-                expr * const * bv_args = bv_fe->get_args();
-                expr_ref_buffer new_args(m);
+                for (unsigned i = 0; i < bv_fi->num_entries(); i++) {
+                    func_entry const * bv_fe = bv_fi->get_entry(i);
+                    expr * const * bv_args = bv_fe->get_args();
+                    expr_ref_buffer new_args(m);
 
-                for (unsigned j = 0; j < arity; j++) {
-                    sort * dj = f->get_domain(j);
-                    expr * aj = bv_args[j];
-                    if (fu.is_float(dj))
-                        new_args.push_back(convert_bv2fp(bv_mdl, dj, aj));
-                    else if (fu.is_rm(dj)) {
-                        expr_ref fv(m);
-                        fv = convert_bv2rm(aj);
-                        new_args.push_back(fv);
+                    for (unsigned j = 0; j < arity; j++) {
+                        sort * dj = f->get_domain(j);
+                        expr * aj = bv_args[j];
+                        expr_ref saj(m);
+                        bv_mdl->eval(aj, saj, true);
+
+                        if (fu.is_float(dj))
+                            new_args.push_back(convert_bv2fp(bv_mdl, dj, saj));
+                        else if (fu.is_rm(dj)) {
+                            expr_ref fv(m);
+                            fv = convert_bv2rm(saj);
+                            new_args.push_back(fv);
+                        }
+                        else
+                            new_args.push_back(saj);                        
                     }
-                    else
-                        new_args.push_back(aj);
+
+                    expr_ref ret(m);
+                    ret = bv_fe->get_result();
+                    bv_mdl->eval(ret, ret);
+                    if (fu.is_float(rng))
+                        ret = convert_bv2fp(bv_mdl, rng, ret);
+                    else if (fu.is_rm(rng))
+                        ret = convert_bv2rm(ret);
+
+                    flt_fi->insert_new_entry(new_args.c_ptr(), ret);
                 }
 
-                expr_ref ret(m);
-                ret = bv_fe->get_result();
+                expr_ref els(m);
+                els = bv_fi->get_else();
                 if (fu.is_float(rng))
-                    ret = convert_bv2fp(bv_mdl, rng, ret);
+                    els = convert_bv2fp(bv_mdl, rng, els);
                 else if (fu.is_rm(rng))
-                    ret = convert_bv2rm(ret);
+                    els = convert_bv2rm(els);
 
-                flt_fi->insert_new_entry(new_args.c_ptr(), ret);
+                flt_fi->set_else(els);
+
+                float_mdl->register_decl(f, flt_fi);
             }
-
-            expr_ref els(m);
-            els = bv_fi->get_else();
-            if (fu.is_float(rng))
-                els = convert_bv2fp(bv_mdl, rng, els);
-            else if (fu.is_rm(rng))
-                els = convert_bv2rm(els);
-
-            flt_fi->set_else(els);
-
-            float_mdl->register_decl(f, flt_fi);
         }
         else {
             func_decl * bvf = it->m_value;

--- a/src/tactic/fpa/fpa2bv_model_converter.h
+++ b/src/tactic/fpa/fpa2bv_model_converter.h
@@ -24,11 +24,11 @@ Notes:
 #include"model_converter.h"
 
 class fpa2bv_model_converter : public model_converter {
-    fpa_util    m_fpa_util;
-    bv_util     m_bv_util;
-    th_rewriter m_th_rw;
-
-    ast_manager               & m;
+    ast_manager & m;
+    fpa_util      m_fpa_util;
+    bv_util       m_bv_util;
+    th_rewriter   m_th_rw;
+    
     obj_map<func_decl, expr*>   m_const2bv;
     obj_map<func_decl, expr*>   m_rm_const2bv;
     obj_map<func_decl, func_decl*>  m_uf2bvuf;

--- a/src/tactic/fpa/fpa2bv_model_converter.h
+++ b/src/tactic/fpa/fpa2bv_model_converter.h
@@ -19,10 +19,15 @@ Notes:
 #ifndef FPA2BV_MODEL_CONVERTER_H_
 #define FPA2BV_MODEL_CONVERTER_H_
 
+#include"th_rewriter.h"
 #include"fpa2bv_converter.h"
 #include"model_converter.h"
 
 class fpa2bv_model_converter : public model_converter {
+    fpa_util    m_fpa_util;
+    bv_util     m_bv_util;
+    th_rewriter m_th_rw;
+
     ast_manager               & m;
     obj_map<func_decl, expr*>   m_const2bv;
     obj_map<func_decl, expr*>   m_rm_const2bv;
@@ -30,7 +35,11 @@ class fpa2bv_model_converter : public model_converter {
     obj_map<func_decl, std::pair<app*, app*> > m_specials;
 
 public:
-    fpa2bv_model_converter(ast_manager & m, fpa2bv_converter const & conv) : m(m) {
+    fpa2bv_model_converter(ast_manager & m, fpa2bv_converter const & conv) : 
+        m(m),
+        m_fpa_util(m),
+        m_bv_util(m),
+        m_th_rw(m) {
         for (obj_map<func_decl, expr*>::iterator it = conv.m_const2bv.begin();
              it != conv.m_const2bv.end();
              it++)
@@ -95,13 +104,32 @@ public:
     virtual model_converter * translate(ast_translation & translator);
 
 protected:
-    fpa2bv_model_converter(ast_manager & m) : m(m){ }
+    fpa2bv_model_converter(ast_manager & m) : 
+        m(m),
+        m_fpa_util(m),
+        m_bv_util(m),
+        m_th_rw(m) {}
 
     void convert(model * bv_mdl, model * float_mdl);
-    expr_ref convert_bv2fp(sort * s, expr * sgn, expr * exp, expr * sig) const;
-    expr_ref convert_bv2fp(model * bv_mdl, sort * s, expr * bv) const;
-    expr_ref convert_bv2rm(expr * eval_v) const;
-    expr_ref convert_bv2rm(model * bv_mdl, func_decl * var, expr * val) const;
+    expr_ref convert_bv2fp(sort * s, expr * sgn, expr * exp, expr * sig);
+    expr_ref convert_bv2fp(model * bv_mdl, sort * s, expr * bv);
+    expr_ref convert_bv2rm(expr * eval_v);
+    expr_ref convert_bv2rm(model * bv_mdl, expr * val);
+
+    func_interp * convert_func_interp(func_decl * f, func_decl * bv_f, model * bv_mdl);
+    expr_ref rebuild_floats(model * bv_mdl, sort * s, expr * e);
+    
+    
+    class array_model {
+    public:
+        func_decl * new_float_fd;
+        func_interp * new_float_fi;
+        func_decl * bv_fd;
+        expr_ref result;
+        array_model(ast_manager & m) : result(m) {}
+    };
+
+    array_model convert_array_func_interp(func_decl * f, func_decl * bv_f, model * bv_mdl);
 };
 
 

--- a/src/tactic/fpa/fpa2bv_model_converter.h
+++ b/src/tactic/fpa/fpa2bv_model_converter.h
@@ -32,6 +32,7 @@ class fpa2bv_model_converter : public model_converter {
     obj_map<func_decl, expr*>   m_const2bv;
     obj_map<func_decl, expr*>   m_rm_const2bv;
     obj_map<func_decl, func_decl*>  m_uf2bvuf;
+    obj_map<sort, sort*>        m_subst_sorts;
     obj_map<func_decl, std::pair<app*, app*> > m_specials;
 
 public:
@@ -64,6 +65,14 @@ public:
             m.inc_ref(it->m_key);
             m.inc_ref(it->m_value);
         }
+        for (obj_map<sort, sort*>::iterator it = conv.m_subst_sorts.begin();
+            it != conv.m_subst_sorts.end();
+            it++)
+        {
+            m_subst_sorts.insert(it->m_key, it->m_value);
+            m.inc_ref(it->m_key);
+            m.inc_ref(it->m_value);
+        }
         for (obj_map<func_decl, std::pair<app*, app*> >::iterator it = conv.m_specials.begin();
              it != conv.m_specials.end();
              it++) {
@@ -78,6 +87,7 @@ public:
         dec_ref_map_key_values(m, m_const2bv);
         dec_ref_map_key_values(m, m_rm_const2bv);
         dec_ref_map_key_values(m, m_uf2bvuf);
+        dec_ref_map_key_values(m, m_subst_sorts);
         for (obj_map<func_decl, std::pair<app*, app*> >::iterator it = m_specials.begin();
              it != m_specials.end();
              it++) {

--- a/src/tactic/fpa/fpa2bv_model_converter.h
+++ b/src/tactic/fpa/fpa2bv_model_converter.h
@@ -32,7 +32,6 @@ class fpa2bv_model_converter : public model_converter {
     obj_map<func_decl, expr*>   m_const2bv;
     obj_map<func_decl, expr*>   m_rm_const2bv;
     obj_map<func_decl, func_decl*>  m_uf2bvuf;
-    obj_map<sort, sort*>        m_subst_sorts;
     obj_map<func_decl, std::pair<app*, app*> > m_specials;
 
 public:
@@ -65,14 +64,6 @@ public:
             m.inc_ref(it->m_key);
             m.inc_ref(it->m_value);
         }
-        for (obj_map<sort, sort*>::iterator it = conv.m_subst_sorts.begin();
-            it != conv.m_subst_sorts.end();
-            it++)
-        {
-            m_subst_sorts.insert(it->m_key, it->m_value);
-            m.inc_ref(it->m_key);
-            m.inc_ref(it->m_value);
-        }
         for (obj_map<func_decl, std::pair<app*, app*> >::iterator it = conv.m_specials.begin();
              it != conv.m_specials.end();
              it++) {
@@ -87,7 +78,6 @@ public:
         dec_ref_map_key_values(m, m_const2bv);
         dec_ref_map_key_values(m, m_rm_const2bv);
         dec_ref_map_key_values(m, m_uf2bvuf);
-        dec_ref_map_key_values(m, m_subst_sorts);
         for (obj_map<func_decl, std::pair<app*, app*> >::iterator it = m_specials.begin();
              it != m_specials.end();
              it++) {
@@ -128,15 +118,14 @@ protected:
 
     func_interp * convert_func_interp(func_decl * f, func_decl * bv_f, model * bv_mdl);
     expr_ref rebuild_floats(model * bv_mdl, sort * s, expr * e);
-    
-    
+        
     class array_model {
     public:
         func_decl * new_float_fd;
         func_interp * new_float_fi;
         func_decl * bv_fd;
         expr_ref result;
-        array_model(ast_manager & m) : result(m) {}
+        array_model(ast_manager & m) : new_float_fd(0), new_float_fi(0), bv_fd(0), result(m) {}
     };
 
     array_model convert_array_func_interp(func_decl * f, func_decl * bv_f, model * bv_mdl);

--- a/src/test/model_based_opt.cpp
+++ b/src/test/model_based_opt.cpp
@@ -216,6 +216,77 @@ static void test4() {
     std::cout << "u: " << mbo.get_value(u) << "\n";
 }
 
+static void test5() {
+    opt::model_based_opt mbo;
+    unsigned x = mbo.add_var(rational(2));
+    unsigned y = mbo.add_var(rational(3));
+    unsigned z = mbo.add_var(rational(4));
+    unsigned u = mbo.add_var(rational(5));
+
+    add_ineq(mbo, x, 1, y, -1, 0, opt::t_le);
+    add_ineq(mbo, x, 1, z, -1, 0, opt::t_le);
+    add_ineq(mbo, y, 1, u, -1, 0, opt::t_le);
+    add_ineq(mbo, z, 1, u, -1, 1, opt::t_le);
+
+    unsigned vars[2] = { y, z };
+    mbo.project(1, vars);    
+    mbo.display(std::cout);
+
+    mbo.project(1, vars);    
+    mbo.display(std::cout);
+
+    mbo.project(1, vars+1);
+    mbo.display(std::cout);
+
+    vector<opt::model_based_opt::row> rows;
+    mbo.get_live_rows(rows);
+}
+
+
+static void test6() {
+    opt::model_based_opt mbo;
+    unsigned x0 = mbo.add_var(rational(1));
+    unsigned x = mbo.add_var(rational(2));
+    unsigned y = mbo.add_var(rational(3));
+    unsigned z = mbo.add_var(rational(4));
+    unsigned u = mbo.add_var(rational(5));
+    unsigned v = mbo.add_var(rational(6));
+    unsigned w = mbo.add_var(rational(6));
+
+    add_ineq(mbo, x0, 1, y, -1, 0, opt::t_le);
+    add_ineq(mbo, x, 1, y, -1, 0, opt::t_le);
+    add_ineq(mbo, y, 1, u, -1, 0, opt::t_le);
+    add_ineq(mbo, y, 1, z, -1, 1, opt::t_le);
+    add_ineq(mbo, y, 1, v, -1, 1, opt::t_le);
+    add_ineq(mbo, y, 1, w, -1, 1, opt::t_le);
+
+    mbo.display(std::cout);
+    mbo.project(1, &y);
+    mbo.display(std::cout);
+}
+
+static void test7() {
+    opt::model_based_opt mbo;
+    unsigned x0 = mbo.add_var(rational(2));
+    unsigned x = mbo.add_var(rational(1));
+    unsigned y = mbo.add_var(rational(3));
+    unsigned z = mbo.add_var(rational(4));
+    unsigned u = mbo.add_var(rational(5));
+    unsigned v = mbo.add_var(rational(6));
+    unsigned w = mbo.add_var(rational(6));
+
+    add_ineq(mbo, x0, 1, y, -1, 0, opt::t_le);
+    add_ineq(mbo, x, 1, y, -1, 0, opt::t_lt);
+    add_ineq(mbo, y, 1, u, -1, 0, opt::t_le);
+    add_ineq(mbo, y, 1, z, -1, 1, opt::t_le);
+    add_ineq(mbo, y, 1, v, -1, 1, opt::t_le);
+    add_ineq(mbo, y, 1, w, -1, 1, opt::t_lt);
+
+    mbo.display(std::cout);
+    mbo.project(1, &y);
+    mbo.display(std::cout);
+}
+
 // test with mix of upper and lower bounds
 
 void tst_model_based_opt() {
@@ -224,4 +295,8 @@ void tst_model_based_opt() {
     test2();
     test3();
     test4();
+    test5();
+    test6();
+    test7();
+
 }

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1092,6 +1092,7 @@ void mpf_manager::round_to_integral(mpf_rounding_mode rm, mpf const & x, mpf & o
             bool tie = m_mpz_manager.eq(rem, shiftm1_p);
             bool less_than_tie = m_mpz_manager.lt(rem, shiftm1_p);
             bool more_than_tie = m_mpz_manager.gt(rem, shiftm1_p);
+            (void)less_than_tie;
             TRACE("mpf_dbg", tout << "tie= " << tie << "; <tie = " << less_than_tie << "; >tie = " << more_than_tie << std::endl;);
             if (tie) {
                 if ((rm == MPF_ROUND_NEAREST_TEVEN && m_mpz_manager.is_odd(div)) ||
@@ -1888,6 +1889,7 @@ void mpf_manager::round(mpf_rounding_mode rm, mpf & o) {
 
     const mpz & p_m1 = m_powers2(o.sbits+2);
     const mpz & p_m2 = m_powers2(o.sbits+3);
+    (void)p_m1;    
 
     TRACE("mpf_dbg", tout << "p_m1 = " << m_mpz_manager.to_string(p_m1) << std::endl <<
                              "p_m2 = " << m_mpz_manager.to_string(p_m2) << std::endl;);
@@ -2079,7 +2081,7 @@ void mpf_manager::round_sqrt(mpf_rounding_mode rm, mpf & o) {
     bool round = !m_mpz_manager.is_even(o.significand);
     m_mpz_manager.machine_div2k(o.significand, 1);
     bool last = !m_mpz_manager.is_even(o.significand);
-
+    (void)last;
     bool inc = false;
 
     // Specialized rounding for sqrt, as there are no negative cases (or half-way cases?)

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1218,9 +1218,6 @@ void mpf_manager::renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, m
     if (m_mpz_manager.is_zero(sig))
         return;
 
-    mpf_exp_t max_e = mk_max_exp(ebits);
-    mpf_exp_t min_e = mk_min_exp(ebits);
-
     const mpz & pg = m_powers2(sbits);
     while (m_mpz_manager.ge(sig, pg)) {
         m_mpz_manager.machine_div2k(sig, 1);
@@ -1237,8 +1234,7 @@ void mpf_manager::renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, m
 void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & exp_diff, bool partial) {
     unsigned ebits = x.ebits;
     unsigned sbits = x.sbits;
-    bool sign = x.sign;
-
+    
     SASSERT(-1 <= exp_diff && exp_diff < INT64_MAX);
     SASSERT(exp_diff < ebits+sbits || partial);
 

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1428,7 +1428,7 @@ void mpf_manager::rem(mpf const & x, mpf const & y, mpf & o) {
         const mpf_exp_t B = x.sbits;
         mpf_exp_t D;
         do {
-            if (ST0.exponent() < (ST1.exponent()) - 1) {
+            if (ST0.exponent() < ST1.exponent() - 1) {
                 D = 0;                    
             }
             else {

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1095,7 +1095,7 @@ void mpf_manager::round_to_integral(mpf_rounding_mode rm, mpf const & x, mpf & o
             TRACE("mpf_dbg", tout << "tie= " << tie << "; <tie = " << less_than_tie << "; >tie = " << more_than_tie << std::endl;);
             if (tie) {
                 if ((rm == MPF_ROUND_NEAREST_TEVEN && m_mpz_manager.is_odd(div)) ||
-                    (rm == MPF_ROUND_NEAREST_TAWAY && m_mpz_manager.is_even(div))) {
+                    (rm == MPF_ROUND_NEAREST_TAWAY)) {
                     TRACE("mpf_dbg", tout << "div++ (1)" << std::endl;);
                     m_mpz_manager.inc(div);
                 }

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1214,149 +1214,192 @@ void mpf_manager::to_ieee_bv_mpz(const mpf & x, scoped_mpz & o) {
     }
 }
 
-void mpf_manager::prem(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & exp_diff, bool partial) {
+void mpf_manager::renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, mpz & sig) {
+    if (m_mpz_manager.is_zero(sig))
+        return;
+
+    mpf_exp_t max_e = mk_max_exp(ebits);
+    mpf_exp_t min_e = mk_min_exp(ebits);
+
+    const mpz & pg = m_powers2(sbits);
+    while (m_mpz_manager.ge(sig, pg)) {
+        m_mpz_manager.machine_div2k(sig, 1);
+        exp++;
+    }
+    
+    const mpz & pl = m_powers2(sbits-1);
+    while (m_mpz_manager.lt(sig, pl)) {
+        m_mpz_manager.mul2k(sig, 1);
+        exp--;
+    }
+}
+
+void mpf_manager::partial_remainder(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & exp_diff, bool partial) {
     unsigned ebits = x.get().ebits;
     unsigned sbits = x.get().sbits;
     bool sign = x.get().sign;
 
-    signed int D = (unsigned)(partial ? 0 : exp_diff);
-    mpf_exp_t N = sbits/2;
+    SASSERT(-1 <= exp_diff && exp_diff < INT64_MAX);
+    SASSERT(exp_diff < ebits+sbits || partial);
+
+    signed int D = (signed int)(exp_diff);
+    mpf_exp_t N = (sbits+ebits)/2;
 
     TRACE("mpf_dbg_rem", tout << "x=" << to_string(x) << std::endl;
                          tout << "y=" << to_string(y) << std::endl;
                          tout << "d=" << D << std::endl;
                          tout << "partial=" << partial << std::endl;);
 
-    // 1. Compute a/b
-    unsigned extra_bits = sbits + 2;
-    scoped_mpz x_sig_shifted(m_mpz_manager), x_div_y_sig_lrg(m_mpz_manager);
-    scoped_mpz x_div_y_sig(m_mpz_manager), x_rem_y_sig(m_mpz_manager);
-    m_mpz_manager.mul2k(x.significand(), sbits + extra_bits, x_sig_shifted);
-    m_mpz_manager.machine_div(x_sig_shifted, y.significand(), x_div_y_sig_lrg);
-    m_mpz_manager.machine_div_rem(x_div_y_sig_lrg, m_powers2(extra_bits-2), x_div_y_sig, x_rem_y_sig);
-    TRACE("mpf_dbg_rem", tout << "X/Y_sig=" << m_mpz_manager.to_string(x_div_y_sig) << std::endl;
-                         tout << "X%Y_sig=" << m_mpz_manager.to_string(x_rem_y_sig) << std::endl;
-                         tout << "X/Y=" << to_string_hexfloat(
-                            to_packed_mpf(x.sign(), D, x_div_y_sig, ebits, sbits, 3)) << std::endl;);
-    SASSERT(m_mpz_manager.lt(x_div_y_sig, m_powers2(sbits + 3))); // 3 extra bits in x_div_y_sig.
-    SASSERT(m_mpz_manager.ge(x_div_y_sig, m_powers2(sbits - 1 + 3)));
-    // Bug: a_rem_b_sig is not used.
+    SASSERT(m_mpz_manager.lt(x.significand(), m_powers2(sbits)));
+    SASSERT(m_mpz_manager.ge(x.significand(), m_powers2(sbits - 1)));
+    SASSERT(m_mpz_manager.lt(y.significand(), m_powers2(sbits)));
+    SASSERT(m_mpz_manager.ge(y.significand(), m_powers2(sbits - 1)));
+
+    // 1. Compute a/b        
+    bool x_div_y_sgn = x.sign() ^ y.sign();
+    mpf_exp_t x_div_y_exp = D;
+    scoped_mpz x_sig_shifted(m_mpz_manager), x_div_y_sig_lrg(m_mpz_manager), x_div_y_rem(m_mpz_manager);
+    scoped_mpz x_rem_y_sig(m_mpz_manager);
+    m_mpz_manager.mul2k(x.significand(), 2*sbits + 2, x_sig_shifted);
+    m_mpz_manager.machine_div_rem(x_sig_shifted, y.significand(), x_div_y_sig_lrg, x_div_y_rem); // rem useful?
+    // x/y is in x_diuv_y_sig_lrg and has sbits+3 extra bits.
+
+    TRACE("mpf_dbg_rem", tout << "X/Y_exp=" << x_div_y_exp << std::endl;
+                         tout << "X/Y_sig_lrg=" << m_mpz_manager.to_string(x_div_y_sig_lrg) << std::endl;
+                         tout << "X/Y_rem=" << m_mpz_manager.to_string(x_div_y_rem) << std::endl;
+                         scoped_mpf & XdY = to_packed_mpf(x_div_y_sgn, x_div_y_exp, x_div_y_sig_lrg, ebits, sbits, sbits+3);
+                         tout << "X/Y~=" << to_string_hexfloat(XdY) << std::endl;);
 
     // 2. Round a/b to integer Q/QQ
-    mpf_exp_t Q_exp = partial ? N : D;
+    bool Q_sgn = x_div_y_sgn;
+    mpf_exp_t Q_exp = x_div_y_exp;
     scoped_mpz Q_sig(m_mpz_manager), Q_rem(m_mpz_manager);
-    if (partial) {
+    unsigned Q_shft = (sbits-1) + (sbits+3) -  (unsigned) (partial ? N :Q_exp);
+    if (partial) {        
         // Round according to MPF_ROUND_TOWARD_ZERO
-        SASSERT(N < D && D < INT_MAX);
-        unsigned D_N = (unsigned)(D-N);
-        unsigned Q_shft = (sbits - 1) - D_N;
-        m_mpz_manager.machine_div_rem(x_div_y_sig, m_powers2(Q_shft+3), Q_sig, Q_rem);
-        m_mpz_manager.mul2k(Q_sig, Q_shft);
+        SASSERT(0 < N && N < Q_exp && Q_exp < INT_MAX);
+        m_mpz_manager.machine_div2k(x_div_y_sig_lrg, Q_shft, Q_sig);
     }
     else {
         // Round according to MPF_ROUND_NEAREST_TEVEN
-        unsigned Q_shft = (sbits - 1) - D;
-        m_mpz_manager.machine_div_rem(x_div_y_sig, m_powers2(Q_shft+3), Q_sig, Q_rem);
+        m_mpz_manager.machine_div_rem(x_div_y_sig_lrg, m_powers2(Q_shft), Q_sig, Q_rem);
         const mpz & shiftm1_p = m_powers2(Q_shft-1);
         bool tie = m_mpz_manager.eq(Q_rem, shiftm1_p);
         bool more_than_tie = m_mpz_manager.gt(Q_rem, shiftm1_p);
         TRACE("mpf_dbg_rem", tout << "tie= " << tie << "; >tie= " << more_than_tie << std::endl;);
         if ((tie && m_mpz_manager.is_odd(Q_sig)) || more_than_tie)
             m_mpz_manager.inc(Q_sig);
-        m_mpz_manager.mul2k(Q_sig, Q_shft);
-        SASSERT(m_mpz_manager.ge(Q_sig, m_powers2(sbits-1)));
     }
-    TRACE("mpf_dbg_rem", tout << "Q_sig'=" << m_mpz_manager.to_string(Q_sig) << std::endl;
-                         tout << "Q_rem=" << m_mpz_manager.to_string(Q_rem) << std::endl; );
-
-    // re-normalize Q
-    while (m_mpz_manager.ge(Q_sig, m_powers2(sbits))) {
-        m_mpz_manager.machine_div2k(Q_sig, 1);
-        Q_exp++;
-    }
+    m_mpz_manager.mul2k(Q_sig, Q_shft);
+    m_mpz_manager.machine_div2k(Q_sig, sbits+3);
+    renormalize(ebits, sbits, Q_exp, Q_sig);
 
     TRACE("mpf_dbg_rem", tout << "Q_exp=" << Q_exp << std::endl;
                          tout << "Q_sig=" << m_mpz_manager.to_string(Q_sig) << std::endl;
-                         scoped_mpf & Q = to_packed_mpf(x.sign(), Q_exp, Q_sig, ebits, sbits, 0);
+                         scoped_mpf & Q = to_packed_mpf(Q_sgn, Q_exp, Q_sig, ebits, sbits, 0);
                          tout << "Q=" << to_string_hexfloat(Q) << std::endl;);
+        
+    if ((D == -1 || partial) && m_mpz_manager.is_zero(Q_sig))
+        return; // This means x % y = x.
+
+    // no extra bits in Q_sig.
+    SASSERT(!m_mpz_manager.is_zero(Q_sig));
+    SASSERT(m_mpz_manager.lt(Q_sig, m_powers2(sbits)));
+    SASSERT(m_mpz_manager.ge(Q_sig, m_powers2(sbits - 1)));
+
 
     // 3. Compute Y*Q / Y*QQ*2^{D-N}
+    bool YQ_sgn = y.sign() ^ Q_sgn;
     scoped_mpz YQ_sig(m_mpz_manager);
-    mpf_exp_t YQ_exp = (Q_exp + y.exponent()) + (partial ? D-N : 0);
-    m_mpz_manager.mul(y.significand(), Q_sig, YQ_sig);
+    mpf_exp_t YQ_exp = Q_exp + y.exponent();
+    m_mpz_manager.mul(y.significand(), Q_sig, YQ_sig);    
+    renormalize(ebits, 2*sbits-1, YQ_exp, YQ_sig); // YQ_sig has `sbits-1' extra bits.
 
-    if (sbits >= 7) {
-        scoped_mpz sticky_rem(m_mpz_manager);
-        m_mpz_manager.machine_div_rem(YQ_sig, m_powers2(sbits-7), YQ_sig, sticky_rem);
-        if (!m_mpz_manager.is_zero(sticky_rem) && m_mpz_manager.is_even(YQ_sig))
-            m_mpz_manager.inc(YQ_sig);
-    }
-    else
-        m_mpz_manager.mul2k(YQ_sig, 7-sbits, YQ_sig);
-
-    TRACE("mpf_dbg_rem", tout << "YQ_exp=" << YQ_exp << std::endl;
+    TRACE("mpf_dbg_rem", tout << "YQ_sgn=" << YQ_sgn << std::endl;
+                         tout << "YQ_exp=" << YQ_exp << std::endl;
                          tout << "YQ_sig=" << m_mpz_manager.to_string(YQ_sig) << std::endl;
-                         scoped_mpf & YQ = to_packed_mpf(x.sign(), YQ_exp, YQ_sig, ebits, sbits, 6);
+                         scoped_mpf & YQ = to_packed_mpf(YQ_sgn, YQ_exp, YQ_sig, ebits, sbits, sbits-1);
                          tout << "YQ=" << to_string_hexfloat(YQ) << std::endl;);
 
-    // 4. Compute X-Y*Q
-    bool YQ_sgn = !x.sign();
-    mpf_exp_t X_YQ_exp = x.exponent() - 3;
+    // `sbits-1' extra bits in YQ_sig.    
+    SASSERT(m_mpz_manager.lt(YQ_sig, m_powers2(2*sbits-1)));
+    SASSERT(m_mpz_manager.ge(YQ_sig, m_powers2(2*sbits-2)) || YQ_exp <= mk_bot_exp(ebits));
+
+    // 4. Compute X-Y*Q    
+    mpf_exp_t X_YQ_exp = x.exponent();
     scoped_mpz X_YQ_sig(m_mpz_manager);
     mpf_exp_t exp_delta = exp(x) - YQ_exp;
     TRACE("mpf_dbg_rem", tout << "exp_delta=" << exp_delta << std::endl;);
+    SASSERT(INT_MIN < exp_delta && exp_delta <= INT_MAX);
     scoped_mpz minuend(m_mpz_manager), subtrahend(m_mpz_manager);
 
-    if (exp_delta >= 0) {
-        m_mpz_manager.set(minuend, x.significand());
-        m_mpz_manager.set(subtrahend, YQ_sig);
-    }
-    else if (exp_delta < 0) {
-        m_mpz_manager.set(minuend, YQ_sig);
-        m_mpz_manager.set(subtrahend, x.significand());
-        YQ_sgn = !YQ_sgn;
-        exp_delta = -exp_delta;
-    }
+    scoped_mpz x_sig_lrg(m_mpz_manager);
+    m_mpz_manager.mul2k(x.significand(), sbits-1, x_sig_lrg); // sbits-1 extra bits into x
 
+    m_mpz_manager.set(minuend, x_sig_lrg);
+    m_mpz_manager.set(subtrahend, YQ_sig);
+
+    SASSERT(m_mpz_manager.lt(minuend, m_powers2(2*sbits-1)));
+    SASSERT(m_mpz_manager.ge(minuend, m_powers2(2*sbits-2)));
+    SASSERT(m_mpz_manager.lt(subtrahend, m_powers2(2*sbits-1)));
+    SASSERT(m_mpz_manager.ge(subtrahend, m_powers2(2*sbits-2)));
+    
     if (exp_delta != 0) {
         scoped_mpz sticky_rem(m_mpz_manager);
-        if (exp_delta > sbits+5) {
-            m_mpz_manager.set(sticky_rem, 0);
-            sticky_rem.swap(subtrahend);
+        m_mpz_manager.set(sticky_rem, 0);
+        if (exp_delta > sbits+5)
+            sticky_rem.swap(subtrahend);        
+        else if (exp_delta > 0)
+            m_mpz_manager.machine_div_rem(subtrahend, m_powers2((unsigned)exp_delta), subtrahend, sticky_rem);        
+        else {
+            SASSERT(exp_delta < 0);
+            exp_delta = -exp_delta;
+            m_mpz_manager.mul2k(subtrahend, (int)exp_delta);
         }
-        else
-            m_mpz_manager.machine_div_rem(subtrahend, m_powers2((unsigned)exp_delta), subtrahend, sticky_rem);
         if (!m_mpz_manager.is_zero(sticky_rem) && m_mpz_manager.is_even(subtrahend))
             m_mpz_manager.inc(subtrahend);
         TRACE("mpf_dbg_rem", tout << "aligned subtrahend=" << m_mpz_manager.to_string(subtrahend) << std::endl;);
     }
+           
+    m_mpz_manager.sub(minuend, subtrahend, X_YQ_sig);
+    TRACE("mpf_dbg_rem", tout << "X_YQ_sig'=" << m_mpz_manager.to_string(X_YQ_sig) << std::endl;);
 
-    scoped_mpz minuend_lrg(m_mpz_manager);
-    m_mpz_manager.mul2k(minuend, 6, minuend_lrg); // + 6 extra bits into X
-    m_mpz_manager.sub(minuend_lrg, subtrahend, X_YQ_sig);
-
-    TRACE("mpf_dbg_rem", tout << "minuend=" << m_mpz_manager.to_string(minuend) << std::endl;
-                         tout << "subtrahend=" << m_mpz_manager.to_string(subtrahend) << std::endl;
-                         tout << "X_YQ_exp=" << X_YQ_exp << std::endl;
-                         tout << "X_YQ_sig=" << m_mpz_manager.to_string(X_YQ_sig) << std::endl;
-                         scoped_mpf & X_YQ = to_packed_mpf(YQ_sgn, X_YQ_exp, X_YQ_sig, ebits, sbits, 3);
-                         tout << "X-YQ=" << to_string_hexfloat(X_YQ) << std::endl;);
-
-    SASSERT(m_mpz_manager.lt(X_YQ_sig, m_powers2(sbits+5)));
+    bool neg = m_mpz_manager.is_neg(X_YQ_sig);
+    if (neg) m_mpz_manager.neg(X_YQ_sig);
+    bool X_YQ_sgn = ((!x.sign() && !YQ_sgn && neg) ||
+                      (x.sign() &&  YQ_sgn && !neg) ||
+                      (x.sign() && !YQ_sgn));
 
     // 5. Rounding
-    if (m_mpz_manager.is_zero(X_YQ_sig)) {
-        TRACE("mpf_dbg_rem", tout << "sig zero" << std::endl;);
+    if (m_mpz_manager.is_zero(X_YQ_sig))
         mk_zero(ebits, sbits, x.sign(), x);
-    }
     else {
-        bool neg = m_mpz_manager.is_neg(X_YQ_sig);
-        if (neg) m_mpz_manager.neg(X_YQ_sig);
-        bool X_YQ_sgn = ((!x.sign() &&  YQ_sgn && neg) ||
-                          (x.sign() && !YQ_sgn && !neg) ||
-                          (x.sign() &&  YQ_sgn));
+        renormalize(ebits, 2*sbits-1, X_YQ_exp, X_YQ_sig);
+
+        TRACE("mpf_dbg_rem", tout << "minuend=" << m_mpz_manager.to_string(minuend) << std::endl;
+        tout << "subtrahend=" << m_mpz_manager.to_string(subtrahend) << std::endl;
+        tout << "X_YQ_sgn=" << X_YQ_sgn << std::endl;
+        tout << "X_YQ_exp=" << X_YQ_exp << std::endl;
+        tout << "X_YQ_sig=" << m_mpz_manager.to_string(X_YQ_sig) << std::endl;
+        scoped_mpf & X_YQ = to_packed_mpf(X_YQ_sgn, X_YQ_exp, X_YQ_sig, ebits, sbits, sbits-1);
+        tout << "X-YQ=" << to_string_hexfloat(X_YQ) << std::endl;);
+
+        // `sbits-1' extra bits in X_YQ_sig
+        SASSERT(m_mpz_manager.lt(X_YQ_sig, m_powers2(2*sbits-1)));
+        scoped_mpz rnd_bits(m_mpz_manager);
+        m_mpz_manager.machine_div_rem(X_YQ_sig, m_powers2(sbits-1), X_YQ_sig, rnd_bits);
+        TRACE("mpf_dbg_rem", tout << "final sticky=" << m_mpz_manager.to_string(rnd_bits) << std::endl; );
+
+        // Round to nearest, ties to even.
+        if (m_mpz_manager.eq(rnd_bits, mpz(32))) { // tie. 
+            if (m_mpz_manager.is_odd(X_YQ_sig)) {
+                m_mpz_manager.inc(X_YQ_sig);
+            }
+        }
+        else if (m_mpz_manager.gt(rnd_bits, mpz(32)))
+            m_mpz_manager.inc(X_YQ_sig);
+
         set(x, ebits, sbits, X_YQ_sgn, X_YQ_exp, X_YQ_sig);
-        round(MPF_ROUND_NEAREST_TEVEN, x);
     }
 
     TRACE("mpf_dbg_rem", tout << "partial remainder = " << to_string_hexfloat(x) << std::endl;);
@@ -1365,8 +1408,8 @@ void mpf_manager::prem(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & e
 void mpf_manager::rem(mpf const & x, mpf const & y, mpf & o) {
     SASSERT(x.sbits == y.sbits && x.ebits == y.ebits);
 
-    TRACE("mpf_dbg", tout << "X = " << to_string(x) << std::endl;);
-    TRACE("mpf_dbg", tout << "Y = " << to_string(y) << std::endl;);
+    TRACE("mpf_dbg_rem", tout << "X = " << to_string(x) << "=" << to_string_hexfloat(x) << std::endl;
+                         tout << "Y = " << to_string(y) << "=" << to_string_hexfloat(y) << std::endl;);
 
     if (is_nan(x) || is_nan(y))
         mk_nan(x.ebits, x.sbits, o);
@@ -1380,7 +1423,6 @@ void mpf_manager::rem(mpf const & x, mpf const & y, mpf & o) {
         set(o, x);
     else {
         SASSERT(is_regular(x) && is_regular(y));
-        SASSERT(x.exponent >= y.exponent);
 
         // This is a generalized version of the algorithm for FPREM1 in the `Intel
         // 64 and IA-32 Architectures Software Developer's Manual',
@@ -1391,24 +1433,24 @@ void mpf_manager::rem(mpf const & x, mpf const & y, mpf & o) {
         unpack(ST0, true);
         unpack(ST1, true);
 
-        const mpf_exp_t B = x.sbits; // max bits per iteration.
+        const mpf_exp_t B = x.sbits+x.ebits;
         mpf_exp_t D;
         do {
-            D = ST0.exponent() - ST1.exponent();
-            SASSERT(0 <= D && D < INT64_MAX);
+            if (ST0.exponent() < (ST1.exponent()) - 1) {
+                D = 0;                    
+            }
+            else {
+                D = ST0.exponent() - ST1.exponent();
+                partial_remainder(ST0, ST1, D, (D >= B));
+            }
+        } while (D >= B && !ST0.is_zero());
 
-            TRACE("mpf_dbg_rem", tout << "ST0=" << to_string_raw(ST0) << "=" << to_string_hexfloat(ST0) << std::endl;
-                                 tout << "ST1=" << to_string_raw(ST1) << "=" << to_string_hexfloat(ST1)  << std::endl;
-                                 tout << "D=" << D << std::endl;);
-
-            prem(ST0, ST1, D, (D >= B));
-        } while (D >= B);
-
+        m_mpz_manager.mul2k(ST0.significand(), 3);
         set(o, x.ebits, x.sbits, MPF_ROUND_TOWARD_ZERO, ST0);
-        if (is_zero(o))
-            o.sign = x.sign;
+        round(MPF_ROUND_NEAREST_TEVEN, o);
     }
 
+    TRACE("mpf_dbg_rem", tout << "R = " << to_string(o) << "=" << to_string_hexfloat(o) << std::endl; );
     TRACE("mpf_dbg", tout << "REMAINDER = " << to_string(o) << std::endl;);
 }
 
@@ -1538,7 +1580,10 @@ scoped_mpf mpf_manager::to_packed_mpf(bool sgn, mpf_exp_t exp, scoped_mpz const 
     scoped_mpz q_sig(m_mpz_manager);
     m_mpz_manager.set(q_sig, sig);
     if (rbits != 0) m_mpz_manager.div(q_sig, m_powers2(rbits), q_sig); // restore scale
-    m_mpz_manager.sub(q_sig, m_powers2(sbits-1), q_sig); // strip hidden bit
+    if (m_mpz_manager.ge(q_sig, m_powers2(sbits-1)))
+        m_mpz_manager.sub(q_sig, m_powers2(sbits-1), q_sig); // strip hidden bit
+    else if (exp == mk_min_exp(ebits))
+        exp = mk_bot_exp(ebits);
     set(q, ebits, sbits, sgn, exp, q_sig);
     return q;
 }

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1524,9 +1524,9 @@ std::string mpf_manager::to_string(mpf const & x) {
         }
     }
 
-    DEBUG_CODE(
-       res += " " + to_string_raw(x);
-    );
+    //DEBUG_CODE(
+    //   res += " " + to_string_raw(x);
+    //);
 
     return res;
 }

--- a/src/util/mpf.h
+++ b/src/util/mpf.h
@@ -224,7 +224,7 @@ protected:
     void round_sqrt(mpf_rounding_mode rm, mpf & o);
 
     void renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, mpz & sig);
-    void partial_remainder(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & exp_diff, bool partial);
+    void partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & exp_diff, bool partial);
 
     void mk_round_inf(mpf_rounding_mode rm, mpf & o);
 
@@ -285,9 +285,8 @@ protected:
     };
 
     std::string to_string_raw(mpf const & a);
-    std::string to_string_hexfloat(mpf const & a);
-    scoped_mpf to_packed_mpf(bool sgn, mpf_exp_t exp, scoped_mpz const & sig, unsigned ebits, unsigned sbits, unsigned rbits);
-
+    std::string to_string_hexfloat(mpf const & a);    
+    std::string to_string_hexfloat(bool sgn, mpf_exp_t exp, scoped_mpz const & sig, unsigned ebits, unsigned sbits, unsigned rbits);
 public:
     powers2 m_powers2;
 };

--- a/src/util/mpf.h
+++ b/src/util/mpf.h
@@ -185,9 +185,6 @@ public:
     void mk_pinf(unsigned ebits, unsigned sbits, mpf & o);
     void mk_ninf(unsigned ebits, unsigned sbits, mpf & o);
 
-    std::string to_string_raw(mpf const & a);
-    std::string to_string_hexfloat(mpf const & a);
-
     unsynch_mpz_manager & mpz_manager(void) { return m_mpz_manager; }
     unsynch_mpq_manager & mpq_manager(void) { return m_mpq_manager; }
 
@@ -225,6 +222,8 @@ protected:
     void add_sub(mpf_rounding_mode rm, mpf const & x, mpf const & y, mpf & o, bool sub);
     void round(mpf_rounding_mode rm, mpf & o);
     void round_sqrt(mpf_rounding_mode rm, mpf & o);
+
+    void prem(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & exp_diff, bool partial);
 
     void mk_round_inf(mpf_rounding_mode rm, mpf & o);
 
@@ -284,6 +283,10 @@ protected:
         }
     };
 
+    std::string to_string_raw(mpf const & a);
+    std::string to_string_hexfloat(mpf const & a);
+    scoped_mpf to_packed_mpf(bool sgn, mpf_exp_t exp, scoped_mpz const & sig, unsigned ebits, unsigned sbits, unsigned rbits);
+
 public:
     powers2 m_powers2;
 };
@@ -291,6 +294,7 @@ public:
 class scoped_mpf : public _scoped_numeral<mpf_manager> {
     friend class mpf_manager;
     mpz & significand() { return get().significand; }
+    const mpz & significand() const { return get().significand; }
     bool sign() const { return get().sign; }
     mpf_exp_t exponent() const { return get().exponent; }
     unsigned sbits() const { return get().sbits; }

--- a/src/util/mpf.h
+++ b/src/util/mpf.h
@@ -223,7 +223,8 @@ protected:
     void round(mpf_rounding_mode rm, mpf & o);
     void round_sqrt(mpf_rounding_mode rm, mpf & o);
 
-    void prem(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & exp_diff, bool partial);
+    void renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, mpz & sig);
+    void partial_remainder(scoped_mpf & x, scoped_mpf const & y, mpf_exp_t const & exp_diff, bool partial);
 
     void mk_round_inf(mpf_rounding_mode rm, mpf & o);
 

--- a/src/util/mpff.cpp
+++ b/src/util/mpff.cpp
@@ -1395,6 +1395,7 @@ unsigned mpff_manager::prev_power_of_two(mpff const & a) {
 bool mpff_manager::check(mpff const & n) const {
     // n is zero or the most significand bit of the most significand word is 1.
     unsigned * s = sig(n);
+    (void)s;
     SASSERT(is_zero(n) || (s[m_precision - 1] & MIN_MSW) != 0);
     // if n is zero, then the sign must be 0
     SASSERT(!is_zero(n) || n.m_sign == 0);

--- a/src/util/mpn.cpp
+++ b/src/util/mpn.cpp
@@ -280,7 +280,6 @@ bool mpn_manager::div_1(mpn_sbuffer & numer, mpn_digit const denom,
     for (size_t j = numer.size()-1; j > 0; j--) {
         temp = (((mpn_double_digit)numer[j]) << DIGIT_BITS) | ((mpn_double_digit)numer[j-1]);
         q_hat = temp / (mpn_double_digit) denom;
-        r_hat = temp % (mpn_double_digit) denom;
         if (q_hat >= BASE) {
             UNREACHABLE(); // is this reachable with normalized v?
         }
@@ -294,11 +293,13 @@ bool mpn_manager::div_1(mpn_sbuffer & numer, mpn_digit const denom,
             quot[j-1]--;
             numer[j] = numer[j-1] + denom;
         }
-        TRACE("mpn_div1", tout << "j=" << j << " q_hat=" << q_hat << " r_hat=" << r_hat;
-                          tout << " ms=" << ms;
-                          tout << " new numer="; display_raw(tout, numer.c_ptr(), numer.size());
-                          tout << " borrow=" << borrow;
-                          tout << std::endl; );
+        TRACE("mpn_div1", 
+              r_hat = temp % (mpn_double_digit) denom;
+              tout << "j=" << j << " q_hat=" << q_hat << " r_hat=" << r_hat;
+              tout << " ms=" << ms;
+              tout << " new numer="; display_raw(tout, numer.c_ptr(), numer.size());
+              tout << " borrow=" << borrow;
+              tout << std::endl; );
     }
 
     return true; // return rem != 0?

--- a/src/util/mpn.cpp
+++ b/src/util/mpn.cpp
@@ -274,7 +274,7 @@ void mpn_manager::div_unnormalize(mpn_sbuffer & numer, mpn_sbuffer & denom,
 
 bool mpn_manager::div_1(mpn_sbuffer & numer, mpn_digit const denom,
                         mpn_digit * quot) const {
-    mpn_double_digit q_hat, temp, r_hat, ms;
+    mpn_double_digit q_hat, temp, ms;
     mpn_digit borrow;
 
     for (size_t j = numer.size()-1; j > 0; j--) {
@@ -294,7 +294,7 @@ bool mpn_manager::div_1(mpn_sbuffer & numer, mpn_digit const denom,
             numer[j] = numer[j-1] + denom;
         }
         TRACE("mpn_div1", 
-              r_hat = temp % (mpn_double_digit) denom;
+              mpn_double_digit r_hat = temp % (mpn_double_digit) denom;
               tout << "j=" << j << " q_hat=" << q_hat << " r_hat=" << r_hat;
               tout << " ms=" << ms;
               tout << " new numer="; display_raw(tout, numer.c_ptr(), numer.size());


### PR DESCRIPTION
This patch ensures that the C-code that is generated for the OCaml stubs obeys the C89 rules. In particular, all local variables are declared at the beginning of a scope.
It is necessary in order to compile the OCaml bindings with older versions of Visual Studio (pre 2013).
